### PR TITLE
add https:// to homepage github link

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -176,7 +176,7 @@ pub fn validate_and_serialize_matches(
         owner: "CHANGE".to_owned(),
         src_sha: "0000000000000000000000000000000000000000000000000000".to_owned(),
         description: "CHANGE".to_owned(),
-        homepage: "github.com/@owner@/@pname@".to_owned(),
+        homepage: "https://github.com/@owner@/@pname@".to_owned(),
     };
 
     if let Some(url) = matches.value_of("from-url") {


### PR DESCRIPTION
before
```nix
nix-template --stdout stdenv --from-url=https://github.com/varlink/libvarlink
Determining latest release for libvarlink
Determining sha256 for libvarlink
{ lib, stdenv, fetchFromGitHub }:

stdenv.mkDerivation rec {
  pname = "libvarlink";
  version = "22";

  src = fetchFromGitHub {
    owner = "varlink";
    repo = pname;
    rev = "version";
    sha256 = "1i15227vlc9k4276r833ndhxrcys9305pf6dga1j0alx2vj85yz2";
  };

  buildInputs = [ ];

  meta = with lib; {
    description = "C implementation of the Varlink protocol and command line tool";
    homepage = "github.com/varlink/libvarlink";
    license = licenses.CHANGE;
    maintainers = with maintainers; [ artturin ];
  };
}
```

after
```nix
./result/bin/nix-template --stdout stdenv --from-url=https://github.com/varlink/libvarlink
Determining latest release for libvarlink
Determining sha256 for libvarlink
{ lib, stdenv, fetchFromGitHub }:

stdenv.mkDerivation rec {
  pname = "libvarlink";
  version = "22";

  src = fetchFromGitHub {
    owner = "varlink";
    repo = pname;
    rev = "version";
    sha256 = "1i15227vlc9k4276r833ndhxrcys9305pf6dga1j0alx2vj85yz2";
  };

  buildInputs = [ ];

  meta = with lib; {
    description = "C implementation of the Varlink protocol and command line tool";
    homepage = "https://github.com/varlink/libvarlink";
    license = licenses.CHANGE;
    maintainers = with maintainers; [ artturin ];
  };
}
```