### PR TITLE
imp: show json path in errors on invalid data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_path_to_error",
  "serial_test",
  "toml",
  "version-compare",
@@ -857,6 +858,15 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd186dd4e1748b2798a2e86789dd77f5834ecda0bf15db76962e8e104bfc9bd"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ regex = "^1.3"
 xdg = "^2.1"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
+serde_path_to_error = "0.1"
 toml = "^0.5.0"
 reqwest = { version = "^0.11.0", features = [ "json", "blocking"] }
 log = "^0.4"

--- a/src/url.rs
+++ b/src/url.rs
@@ -105,7 +105,8 @@ pub fn fetch_pypi_project_info(pypi_repo: &types::PypiRepo) -> types::PypiRespon
         .header("Content", "application/json");
 
     let body = get_json(request).expect("Unable to get remote data.");
-    match serde_json::from_str(&body) {
+    let jd = &mut serde_json::Deserializer::from_str(&body);
+    match serde_path_to_error::deserialize(jd) {
         Ok(s) => s,
         Err(e) => {
             error!(
@@ -133,7 +134,8 @@ pub fn fetch_github_repo_info(repo: &types::GithubRepo) -> types::GhRepoResponse
     }
 
     let body = get_json(request).expect("Unable to get remote data.");
-    match serde_json::from_str(&body) {
+    let jd = &mut serde_json::Deserializer::from_str(&body);
+    match serde_path_to_error::deserialize(jd) {
         Ok(s) => s,
         Err(e) => {
             error!(
@@ -161,7 +163,8 @@ pub fn fetch_github_release_info(repo: &types::GithubRepo) -> types::GhReleaseRe
     }
 
     let body = get_json(request).expect("Unable to get remote data.");
-    match serde_json::from_str(&body) {
+    let jd = &mut serde_json::Deserializer::from_str(&body);
+    match serde_path_to_error::deserialize(jd) {
         Ok(s) => s,
         Err(e) => {
             error!(


### PR DESCRIPTION
before:
```console
[2022-01-08T17:26:59Z ERROR nix_template::url] Unable to parse response from github to json: Error("invalid type: null, expected a string", line: 1, column: 1233)
```

after:
```console
[2022-01-08T17:43:31Z ERROR nix_template::url] Unable to parse response from github to json: Error { path: Path { segments: [Map { key: "description" }] }, original: Error("invalid type: null, expected a string", line: 1, column: 1233) }
```
