### PR TITLE
fix-gh: freshly forked repos don't have the language attribute

### DIFF
--- a/src/types/gh_repo_response.rs
+++ b/src/types/gh_repo_response.rs
@@ -188,7 +188,7 @@ pub struct GhRepoResponse {
     watchers_count: i64,
 
     #[serde(rename = "language")]
-    language: String,
+    language: Option<String>,
 
     #[serde(rename = "has_issues")]
     has_issues: bool,


### PR DESCRIPTION
- it's also not critical to anything
