### PR TITLE
pypi: gracefully handle missing metadata

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -178,7 +178,7 @@ pub fn extract_metadata_from_url(url: &str) -> Result<UrlMetadata> {
                 pname: pypi_repo.project.clone(),
                 license,
                 description: pypi_response.info.summary.trim_end_matches('.').to_string(),
-                homepage: pypi_response.info.home_page.clone(),
+                homepage: pypi_response.info.home_page.unwrap_or("CHANGE".to_string()),
                 fetcher: Fetcher::pypi,
                 owner: None,
             })

--- a/src/types/pypi.rs
+++ b/src/types/pypi.rs
@@ -33,10 +33,10 @@ pub struct PypiResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Info {
     #[serde(rename = "author")]
-    author: String,
+    author: Option<String>,
 
     #[serde(rename = "author_email")]
-    author_email: String,
+    author_email: Option<String>,
 
     #[serde(rename = "bugtrack_url")]
     bugtrack_url: Option<serde_json::Value>,
@@ -57,7 +57,7 @@ pub struct Info {
     download_url: Option<String>,
 
     #[serde(rename = "home_page")]
-    pub home_page: String,
+    pub home_page: Option<String>,
 
     #[serde(rename = "license")]
     pub license: String,

--- a/src/url.rs
+++ b/src/url.rs
@@ -280,7 +280,7 @@ pub fn fill_pypi_info(pypi_repo: &types::PypiRepo, info: &mut types::ExpressionI
             .next();
 
         info.version = latest_version.clone();
-        info.homepage = pypi_response.info.home_page.clone();
+        info.homepage = pypi_response.info.home_page.unwrap_or("CHANGE".to_string());
         info.description = pypi_response.info.summary.trim_end_matches(".").to_string();
 
         info.license = PYPI_TO_NIXPKGS_LICENSE


### PR DESCRIPTION
These don't seem to be guaranteed, allow for missing entries.

closes: #57