### PR TITLE
--nixpkgs: remove, obsolete

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,8 +52,8 @@ EXAMPLES:
 # generate an expression for this package
 $ nix-template rust --from-url https://github.com/jonringer/nix-template
 
-# generate a python package expressison at pkgs/development/python-modules/requests/default.nix
-$ nix-template python --nixpkgs --pname requests
+# generate a python package expression using RFC140 by-name layout
+$ nix-template python --by-name --pname requests
 
 # generate a shell.nix in $PWD
 $ nix-template mkshell
@@ -71,7 +71,7 @@ $ nix-template config nixpkgs-root ~/nixpkgs
                 .default_value("stdenv"),
         )
         .arg(
-            Arg::from_usage("[PATH] 'directory or file to be written. In the case of a directory, a default.nix will be created. When used with --nixpkgs, it will be appended to nixpkgs-root to determine path location.'")
+            Arg::from_usage("[PATH] 'directory or file to be written. In the case of a directory, a default.nix will be created. When used with --by-name, it will be appended to nixpkgs-root to determine path location.'")
                 .default_value("default.nix")
                 .default_value_if("TEMPLATE", Some("mkshell"), "shell.nix")
                 .default_value_if("TEMPLATE", Some("test"), "test.nix"),
@@ -87,7 +87,7 @@ $ nix-template config nixpkgs-root ~/nixpkgs
             ))
         .arg(Arg::from_usage(
             "--no-meta 'Don't include meta section'",
-            ).conflicts_with("nixpkgs"))
+            ).conflicts_with("by-name"))
         .arg(Arg::from_usage(
             "-d,--documentation-links 'Add comments linking to relevant sections of the Nixpkgs contributor guide.'",
             ).takes_value(false))
@@ -148,10 +148,7 @@ $ nix-template config nixpkgs-root ~/nixpkgs
             "-r,--nixpkgs-root [path] 'Set root of the nixpkgs directory'",
             ).env("NIXPKGS_ROOT"))
         .arg(Arg::from_usage(
-            "-n,--nixpkgs 'Intended be used within nixpkgs, will append pname to file path, and print addition statement'",
-        ).takes_value(false))
-        .arg(Arg::from_usage(
-            "--by-name 'RFC140 layout: write the expression to pkgs/by-name/<shard>/<pname>/package.nix (relative to --nixpkgs-root). The shard is the lowercased first two characters of pname. Implies --nixpkgs and skips printing an all-packages.nix addition line, since by-name packages are auto-discovered.'",
+            "--by-name 'RFC140 layout: write the expression to pkgs/by-name/<shard>/<pname>/package.nix (relative to --nixpkgs-root). The shard is the lowercased first two characters of pname. Packages are auto-discovered, so no all-packages.nix addition line is needed.'",
         ).takes_value(false))
         .arg(
             Arg::from_usage("-f,--fetcher [fetcher] 'Fetcher to use'")
@@ -230,9 +227,9 @@ pub fn validate_and_serialize_matches(
     let include_documentation_links: bool = matches.is_present("documentation-links");
     let include_meta: bool = !matches.is_present("no-meta");
 
-    let nixpkgs_layout = matches.is_present("nixpkgs") || matches.is_present("by-name");
+    let nixpkgs_layout = matches.is_present("by-name");
     assert(!(nixpkgs_layout && matches.value_of("pname") == Some("CHANGE") && matches.value_of("from-url") == None),
-        "'-p,--pname' or '-u,--from-url' is required when using the -n,--nixpkgs or --by-name flag");
+        "'-p,--pname' or '-u,--from-url' is required when using the --by-name flag");
 
     if matches.is_present("by-name") {
         match arg_to_type::<Template>(matches.value_of("TEMPLATE")) {
@@ -453,7 +450,7 @@ mod tests {
             "python",
             "-r",
             "/tmp",
-            "-n",
+            "--by-name",
             "-p",
             "requests",
         ]);
@@ -467,16 +464,16 @@ mod tests {
         assert_eq!(m.value_of("nixpkgs-root"), Some("/tmp"));
         assert_eq!(m.is_present("stdout"), false);
         assert_eq!(m.occurrences_of("PATH"), 0);
-        assert_eq!(m.is_present("nixpkgs"), true);
-        assert!(m.occurrences_of("nixpkgs") >= 1);
+        assert_eq!(m.is_present("by-name"), true);
+        assert!(m.occurrences_of("by-name") >= 1);
         assert_eq!(m.occurrences_of("from-url"), 0);
     }
 
     #[test]
     fn test_url() {
-        let m = build_cli().get_matches_from(vec!["nix-template", "python", "-u", "https://pypi.org/project/requests/", "-n"]);
+        let m = build_cli().get_matches_from(vec!["nix-template", "python", "-u", "https://pypi.org/project/requests/", "--by-name"]);
         assert_eq!(m.is_present("stdout"), false);
-        assert_eq!(m.is_present("nixpkgs"), true);
+        assert_eq!(m.is_present("by-name"), true);
         assert_eq!(m.occurrences_of("from-url"), 1);
     }
 
@@ -487,7 +484,7 @@ mod tests {
         assert_eq!(m.value_of("TEMPLATE"), Some("mkshell"));
         assert_eq!(m.value_of("PATH"), Some("shell.nix"));
         assert_eq!(m.value_of("pname"), Some("CHANGE"));
-        assert_eq!(m.is_present("nixpkgs"), false);
+        assert_eq!(m.is_present("by-name"), false);
         assert_eq!(m.occurrences_of("from-url"), 0);
     }
 
@@ -578,10 +575,10 @@ mod tests {
 
     #[test]
     #[serial] // touching global env, ensure serial runs
-    fn test_nixpkgs() {
+    fn test_nixpkgs_root_env() {
         use std::env::{remove_var, set_var};
         set_var("NIXPKGS_ROOT", "/testdir/");
-        let m = build_cli().get_matches_from(vec!["nix-template", "-n"]);
+        let m = build_cli().get_matches_from(vec!["nix-template", "--by-name", "-p", "test"]);
         assert_eq!(m.value_of("nixpkgs-root"), Some("/testdir/"));
         remove_var("NIXPKGS_ROOT");
     }

--- a/src/file_path.rs
+++ b/src/file_path.rs
@@ -1,6 +1,5 @@
 use crate::types::Template;
 use std::path::{Path, PathBuf};
-use std::process::exit;
 
 /// Determine where the file path should be written
 /// Meant to save people time in dealing with file paths
@@ -109,76 +108,6 @@ pub fn nix_file_paths(
         return (file_path, PathBuf::from(""));
     }
 
-    if matches.is_present("nixpkgs") {
-
-        let mut radix: PathBuf;
-        if matches.occurrences_of("PATH") == 0 {
-            // default to nixpkgs path
-            if *template == Template::python_application {
-                eprintln!("No [PATH] provided, defaulting to \"pkgs/applications/misc/\"");
-                radix = PathBuf::from("applications/misc");
-            } else if *template == Template::python || *template == Template::python_package {
-                eprintln!("No [PATH] provided, defaulting to \"pkgs/development/python-modules/\"");
-                radix = PathBuf::from("development/python-modules/");
-            } else if *template == Template::test {
-                eprintln!("No [PATH] provided, defaulting to \"nixos/tests/\"");
-                radix = PathBuf::from("nixos/tests/");
-                radix.push(format!("{}.nix", &pname));
-                return (radix, PathBuf::from(format!("./{}.nix", &pname)));
-            } else if *template == Template::module {
-                eprintln!("A path is required when using the module template.");
-                eprintln!("For example, 'nixos/modules/services/{}.nix", &pname);
-                exit(1);
-            } else {
-                eprintln!("No [PATH] provided, defaulting to \"pkgs/applications/misc/\"");
-                radix = PathBuf::from("applications/misc");
-            }
-        } else {
-            radix = path.strip_prefix("pkgs").unwrap_or(path).to_path_buf();
-        }
-
-        // modules just need the file location
-        if *template == Template::module {
-            radix = path.strip_prefix(".").unwrap_or(path).to_path_buf();
-            radix = radix.strip_prefix("/").unwrap_or(&radix).to_path_buf();
-            radix = radix
-                .strip_prefix("nixos/modules")
-                .unwrap_or(&radix)
-                .to_path_buf();
-
-            let mut module = PathBuf::from("./");
-            module.push(&radix);
-
-            let mut file_path = PathBuf::from(&nixpkgs_root);
-            file_path.push("nixos");
-            file_path.push("modules");
-            file_path.push(&radix);
-
-            return (file_path, module);
-        }
-
-        // assume that they want a directory for the individual package
-        if !radix.ends_with(&pname) && radix.extension() != Some(std::ffi::OsStr::new("nix")) {
-            radix.push(&pname);
-        }
-
-        // nix_path is the path used in pkgs/top-level/*.nix or nixos/tests/all-tests.nix
-        let mut nix_path = PathBuf::from("..");
-        nix_path.push(&radix);
-
-        // file path is the path to the nix expression from NIXPKGS_ROOT
-        let mut file_path = PathBuf::from(&nixpkgs_root);
-        file_path.push("pkgs");
-        file_path.push(&radix);
-
-        // may have specified a specific nix file (E.g path/package.nix)
-        if file_path.is_dir() || file_path.extension() != Some(std::ffi::OsStr::new("nix")) {
-            file_path = file_path.join("default.nix");
-        }
-
-        return (file_path, nix_path);
-    }
-
     let mut path_buf = path.to_path_buf();
 
     // if it's a directory, we need to default to using the default.nix which `import` expects
@@ -206,106 +135,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[test]
-    #[serial]
-    fn test_module() {
-        let m = build_cli().get_matches_from(vec![
-            "nix-template",
-            "module",
-            "-n",
-            "-p",
-            "my-package",
-            "nixos/modules/services/my-package.nix",
-        ]);
-        let expected = (
-            PathBuf::from("nixos/modules/services/my-package.nix"),
-            PathBuf::from("./services/my-package.nix"),
-        );
-        assert_paths(m, expected);
-    }
-
-    #[test]
-    #[serial]
-    fn test_module_long_path() {
-        let m = build_cli().get_matches_from(vec![
-            "nix-template",
-            "module",
-            "-n",
-            "-p",
-            "my-package",
-            "nixos/modules/services/some-pkg-set/my-package.nix",
-        ]);
-        let expected = (
-            PathBuf::from("nixos/modules/services/some-pkg-set/my-package.nix"),
-            PathBuf::from("./services/some-pkg-set/my-package.nix"),
-        );
-        assert_paths(m, expected);
-    }
-
-    #[test]
-    #[serial]
-    fn test_test() {
-        let m = build_cli().get_matches_from(vec!["nix-template", "test", "-n", "-p", "newpkg"]);
-        let expected = (
-            PathBuf::from("nixos/tests/newpkg.nix"),
-            PathBuf::from("./newpkg.nix"),
-        );
-        assert_paths(m, expected);
-    }
-
-    #[test]
-    #[serial]
-    fn test_dir_to_default_nix() {
-        let m =
-            build_cli().get_matches_from(vec!["nix-template", "python", "-p", "requests", "local/"]);
-        let expected = (
-            PathBuf::from("local/default.nix"),
-            PathBuf::from(""),
-        );
-        assert_paths(m, expected);
-    }
-
-    #[test]
-    #[serial]
-    fn test_python() {
-        let m =
-            build_cli().get_matches_from(vec!["nix-template", "python", "-n", "-p", "requests"]);
-        let expected = (
-            PathBuf::from("pkgs/development/python-modules/requests/default.nix"),
-            PathBuf::from("../development/python-modules/requests"),
-        );
-        assert_paths(m, expected);
-    }
-
-    #[test]
-    #[serial]
-    fn test_stdenv_no_path() {
-        let m =
-            build_cli().get_matches_from(vec!["nix-template", "stdenv", "-n", "-p", "mypackage"]);
-        let expected = (
-            PathBuf::from("pkgs/applications/misc/mypackage/default.nix"),
-            PathBuf::from("../applications/misc/mypackage"),
-        );
-        assert_paths(m, expected);
-    }
-
-    #[test]
-    #[serial]
-    fn test_stdenv_path() {
-        let m = build_cli().get_matches_from(vec![
-            "nix-template",
-            "stdenv",
-            "-n",
-            "-p",
-            "mypackage",
-            "pkgs/compilers/test/",
-        ]);
-        let expected = (
-            PathBuf::from("pkgs/compilers/test/mypackage/default.nix"),
-            PathBuf::from("../compilers/test/mypackage"),
-        );
-        assert_paths(m, expected);
-    }
 
     #[test]
     fn by_name_shard_basic() {
@@ -375,18 +204,18 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_stdenv_no_cc_no_path() {
-        // stdenvNoCC mirrors the stdenv default-path behaviour.
+    fn test_stdenv_no_cc_by_name() {
+        // stdenvNoCC with --by-name should use RFC140 layout
         let m = build_cli().get_matches_from(vec![
             "nix-template",
             "stdenvNoCC",
-            "-n",
+            "--by-name",
             "-p",
             "myfont",
         ]);
         let expected = (
-            PathBuf::from("pkgs/applications/misc/myfont/default.nix"),
-            PathBuf::from("../applications/misc/myfont"),
+            PathBuf::from("pkgs/by-name/my/myfont/package.nix"),
+            PathBuf::from(""),
         );
         assert_paths(m, expected);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,10 +149,9 @@ fn main() {
             //     when no explicit PATH was given. (--init-flake with an
             //     explicit PATH preserves the legacy flat layout for scripts
             //     that depend on it.)
-            //   - Never when --nixpkgs / --by-name is in play (those have
-            //     their own canonical placement under nixpkgs).
-            let nixpkgs_layout_active =
-                m.is_present("nixpkgs") || m.is_present("by-name");
+            //   - Never when --by-name is in play (it has its own canonical
+            //     placement under nixpkgs).
+            let nixpkgs_layout_active = m.is_present("by-name");
             let use_structured_layout = !nixpkgs_layout_active
                 && (init_project || init_npins || (init_flake && no_path_given));
 
@@ -519,27 +518,9 @@ for the npins wrapper."
                     println!();
                 }
 
-                // print helpful message about line to be included in pkgs/top-level
-                // RFC140 (--by-name) packages are auto-discovered, so we skip
-                // this hint when --by-name is set.
-                if m.is_present("nixpkgs") && !m.is_present("by-name") {
-                    println!("Please add the following line to the appropriate file:");
-                    println!();
-                    match &info.template {
-                        Template::module => println!("  {}", &info.top_level_path.display()),
-                        Template::test => println!(
-                            "  {} = handleTest {} {{ }};",
-                            &info.pname,
-                            &info.top_level_path.display()
-                        ),
-                        _ => println!(
-                            "  {} = callPackage {} {{ }};",
-                            &info.pname,
-                            &info.top_level_path.display()
-                        ),
-                    }
-                    println!();
-                } else if m.is_present("by-name") {
+                // Note: --by-name packages are auto-discovered via RFC140, so no
+                // manual addition to all-packages.nix is needed.
+                if m.is_present("by-name") {
                     println!();
                     println!(
                         "RFC140 layout: '{}' will be auto-discovered from pkgs/by-name; \


### PR DESCRIPTION
`--by-name` is likely to be much more relevant, and this removes more "optionality" from the command structure