### PR TITLE
Refine template variants

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       hydraJobs = { inherit (legacyPackages) nix-template; };
       checks = { inherit (legacyPackages) nix-template; };              # items to be ran as part of `nix flake check`
       devShells.default = with legacyPackages; mkShell {
-        nativeBuildInputs = [ rustc cargo clippy pkg-config ];
+        nativeBuildInputs = [ rustc cargo clippy pkg-config rustfmt ];
         buildInputs = [ openssl ];
       };
   }) // {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -240,7 +240,7 @@ pub fn validate_and_serialize_matches(
 
     if matches.is_present("by-name") {
         match arg_to_type::<Template>(matches.value_of("TEMPLATE")) {
-            Template::module | Template::test | Template::mkshell => {
+            Template::Module | Template::Test | Template::Mkshell => {
                 assert(false, "--by-name cannot be used with the 'module', 'test', or 'mkshell' templates");
             }
             _ => {}
@@ -303,7 +303,7 @@ pub fn validate_and_serialize_matches(
 
     // Auto-detect template when "auto" is selected (either explicitly or as
     // default). Uses remote source (--from-url) or local directory (CWD).
-    if info.template == Template::auto && !matches.is_present("no-detect") {
+    if info.template == Template::Auto && !matches.is_present("no-detect") {
         let candidates = if matches.is_present("from-url") {
             // Remote detection: materialise source from URL
             crate::detect::detect_template_candidates(&info)
@@ -316,7 +316,7 @@ pub fn validate_and_serialize_matches(
         match candidates.len() {
             0 => {
                 eprintln!("nix-template: no build system detected; defaulting to stdenv");
-                info.template = Template::stdenv;
+                info.template = Template::Stdenv(crate::types::StdenvVariant::Default);
             }
             1 => {
                 eprintln!(
@@ -346,17 +346,17 @@ pub fn validate_and_serialize_matches(
                 }
             }
         }
-    } else if info.template == Template::auto {
+    } else if info.template == Template::Auto {
         // --no-detect was specified
-        info.template = Template::stdenv;
+        info.template = Template::Stdenv(crate::types::StdenvVariant::Default);
     }
 
     // Python format auto-detection: works in both local and remote modes.
     // For remote mode, we materialise the source to inspect pyproject.toml.
     // For local mode without --init-* (which handles this in build.rs),
     // we inspect the current working directory.
-    if info.template == Template::python_package || info.template == Template::python_application {
-        let format = if matches.is_present("from-url") {
+    if info.template.is_python() {
+        let format_str = if matches.is_present("from-url") {
             // Materialise remote source and detect format
             if let Some(source_path) = crate::source::materialise_source(&info) {
                 crate::detect::detect_python_format(&source_path)
@@ -367,7 +367,11 @@ pub fn validate_and_serialize_matches(
             let cwd = std::env::current_dir().unwrap_or_default();
             crate::detect::detect_python_format(&cwd)
         };
-        info.python_format = format;
+        // Update the format in the Python config
+        if let Some(config) = info.template.python_config_mut() {
+            config.format = crate::types::PythonFormat::from_str(&format_str);
+        }
+        info.python_format = format_str;
     }
 
     // Dependency hash prefetching is on by default when --from-url is provided.
@@ -376,11 +380,13 @@ pub fn validate_and_serialize_matches(
         && !matches.is_present("skip-vendor-hashes");
     if should_prefetch_hashes {
         if let Some(hash) = prefetch_dependency_hash(&info) {
-            match info.template {
-                Template::rust => info.cargo_hash = hash,
-                Template::go => info.vendor_hash = hash,
-                Template::npm => info.npm_deps_hash = hash,
-                Template::pnpm => info.pnpm_deps_hash = hash,
+            match &info.template {
+                Template::Rust(_) => info.cargo_hash = hash,
+                Template::Go(_) => info.vendor_hash = hash,
+                Template::Node(config) => match config.variant {
+                    crate::types::NodeVariant::Npm => info.npm_deps_hash = hash,
+                    crate::types::NodeVariant::Pnpm => info.pnpm_deps_hash = hash,
+                },
                 _ => {}
             }
         }
@@ -391,31 +397,31 @@ pub fn validate_and_serialize_matches(
     let infer_enabled = matches.is_present("from-url")
         && !matches.is_present("skip-infer-deps");
     if infer_enabled {
-        match info.template {
-            Template::rust => {
+        match &info.template {
+            Template::Rust(_) => {
                 if let Some((build, native)) = infer_rust_dependencies(&info) {
                     info.build_inputs = build;
                     info.native_build_inputs = native;
                 }
             }
-            Template::go => {
+            Template::Go(_) => {
                 if let Some((build, native)) = infer_go_dependencies(&info) {
                     info.build_inputs = build;
                     info.native_build_inputs = native;
                 }
             }
-            Template::ruby => {
+            Template::Ruby => {
                 ruby::infer_dependencies(&mut info);
             }
-            Template::stdenv | Template::stdenvNoCC => {
+            Template::Stdenv(_) => {
                 buildsystem::infer_buildsystem_dependencies(&mut info);
             }
-            Template::dotnet => {
+            Template::Dotnet => {
                 if let Some(project_file) = infer_dotnet_project_file(&info) {
                     info.project_file = project_file;
                 }
             }
-            Template::python_package | Template::python_application => {
+            Template::Python(_) => {
                 let deps = crate::deps::python::infer_python_dependencies(&info);
                 if !deps.is_empty() {
                     info.propagated_build_inputs = deps;
@@ -507,9 +513,9 @@ pub fn build_expression_info_from_interactive(
     // Skip for Rust when using cargoLock.lockFile (no hash needed).
     if !skip_vendor_hashes && !info.use_cargo_lock_file {
         if let Some(hash) = prefetch_dependency_hash(&info) {
-            match info.template {
-                Template::rust => info.cargo_hash = hash,
-                Template::go => info.vendor_hash = hash,
+            match &info.template {
+                Template::Rust(_) => info.cargo_hash = hash,
+                Template::Go(_) => info.vendor_hash = hash,
                 _ => {}
             }
         }
@@ -520,31 +526,31 @@ pub fn build_expression_info_from_interactive(
         info.build_inputs = build;
         info.native_build_inputs = native;
     } else if infer_deps {
-        match info.template {
-            Template::rust => {
+        match &info.template {
+            Template::Rust(_) => {
                 if let Some((build, native)) = infer_rust_dependencies(&info) {
                     info.build_inputs = build;
                     info.native_build_inputs = native;
                 }
             }
-            Template::go => {
+            Template::Go(_) => {
                 if let Some((build, native)) = infer_go_dependencies(&info) {
                     info.build_inputs = build;
                     info.native_build_inputs = native;
                 }
             }
-            Template::ruby => {
+            Template::Ruby => {
                 ruby::infer_dependencies(&mut info);
             }
-            Template::stdenv | Template::stdenvNoCC => {
+            Template::Stdenv(_) => {
                 buildsystem::infer_buildsystem_dependencies(&mut info);
             }
-            Template::dotnet => {
+            Template::Dotnet => {
                 if let Some(project_file) = infer_dotnet_project_file(&info) {
                     info.project_file = project_file;
                 }
             }
-            Template::python_package | Template::python_application => {
+            Template::Python(_) => {
                 let deps = crate::deps::python::infer_python_dependencies(&info);
                 if !deps.is_empty() {
                     info.propagated_build_inputs = deps;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -415,6 +415,12 @@ pub fn validate_and_serialize_matches(
                     info.project_file = project_file;
                 }
             }
+            Template::python_package | Template::python_application => {
+                let deps = crate::deps::python::infer_python_dependencies(&info);
+                if !deps.is_empty() {
+                    info.propagated_build_inputs = deps;
+                }
+            }
             _ => {}
         }
     }
@@ -536,6 +542,12 @@ pub fn build_expression_info_from_interactive(
             Template::dotnet => {
                 if let Some(project_file) = infer_dotnet_project_file(&info) {
                     info.project_file = project_file;
+                }
+            }
+            Template::python_package | Template::python_application => {
+                let deps = crate::deps::python::infer_python_dependencies(&info);
+                if !deps.is_empty() {
+                    info.propagated_build_inputs = deps;
                 }
             }
             _ => {}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,6 +292,7 @@ pub fn validate_and_serialize_matches(
         native_build_inputs: Vec::new(),
         use_cargo_lock_file: false,
         cargo_lock_git_deps: Vec::new(),
+        go_module_path: String::new(),
         python_format: "setuptools".to_owned(),
     };
 
@@ -487,6 +488,7 @@ pub fn build_expression_info_from_interactive(
         native_build_inputs: Vec::new(),
         use_cargo_lock_file: false,
         cargo_lock_git_deps: Vec::new(),
+        go_module_path: String::new(),
         python_format: "setuptools".to_owned(),
     };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -291,6 +291,7 @@ pub fn validate_and_serialize_matches(
         build_inputs: Vec::new(),
         native_build_inputs: Vec::new(),
         use_cargo_lock_file: false,
+        cargo_lock_git_deps: Vec::new(),
         python_format: "setuptools".to_owned(),
     };
 
@@ -485,6 +486,7 @@ pub fn build_expression_info_from_interactive(
         build_inputs: Vec::new(),
         native_build_inputs: Vec::new(),
         use_cargo_lock_file: false,
+        cargo_lock_git_deps: Vec::new(),
         python_format: "setuptools".to_owned(),
     };
 
@@ -493,8 +495,9 @@ pub fn build_expression_info_from_interactive(
         read_meta_from_url(&url, &mut info, data.include_prereleases);
     }
 
-    // Vendor hash prefetching is enabled by default (opt-out via skip flag)
-    if !skip_vendor_hashes {
+    // Vendor hash prefetching is enabled by default (opt-out via skip flag).
+    // Skip for Rust when using cargoLock.lockFile (no hash needed).
+    if !skip_vendor_hashes && !info.use_cargo_lock_file {
         if let Some(hash) = prefetch_dependency_hash(&info) {
             match info.template {
                 Template::rust => info.cargo_hash = hash,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -290,6 +290,8 @@ pub fn validate_and_serialize_matches(
         domain: "CHANGE".to_owned(),
         build_inputs: Vec::new(),
         native_build_inputs: Vec::new(),
+        use_cargo_lock_file: false,
+        python_format: "setuptools".to_owned(),
     };
 
     if let Some(url) = matches.value_of("from-url") {
@@ -345,6 +347,25 @@ pub fn validate_and_serialize_matches(
     } else if info.template == Template::auto {
         // --no-detect was specified
         info.template = Template::stdenv;
+    }
+
+    // Python format auto-detection: works in both local and remote modes.
+    // For remote mode, we materialise the source to inspect pyproject.toml.
+    // For local mode without --init-* (which handles this in build.rs),
+    // we inspect the current working directory.
+    if info.template == Template::python_package || info.template == Template::python_application {
+        let format = if matches.is_present("from-url") {
+            // Materialise remote source and detect format
+            if let Some(source_path) = crate::source::materialise_source(&info) {
+                crate::detect::detect_python_format(&source_path)
+            } else {
+                "setuptools".to_owned()
+            }
+        } else {
+            let cwd = std::env::current_dir().unwrap_or_default();
+            crate::detect::detect_python_format(&cwd)
+        };
+        info.python_format = format;
     }
 
     // Dependency hash prefetching is on by default when --from-url is provided.
@@ -463,6 +484,8 @@ pub fn build_expression_info_from_interactive(
         domain: "CHANGE".to_owned(),
         build_inputs: Vec::new(),
         native_build_inputs: Vec::new(),
+        use_cargo_lock_file: false,
+        python_format: "setuptools".to_owned(),
     };
 
     // If URL was provided, fetch metadata

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,13 +235,20 @@ pub fn validate_and_serialize_matches(
     let include_meta: bool = !matches.is_present("no-meta");
 
     let nixpkgs_layout = matches.is_present("by-name");
-    assert(!(nixpkgs_layout && matches.value_of("pname") == Some("CHANGE") && matches.value_of("from-url") == None),
-        "'-p,--pname' or '-u,--from-url' is required when using the --by-name flag");
+    assert(
+        !(nixpkgs_layout
+            && matches.value_of("pname") == Some("CHANGE")
+            && matches.value_of("from-url") == None),
+        "'-p,--pname' or '-u,--from-url' is required when using the --by-name flag",
+    );
 
     if matches.is_present("by-name") {
         match arg_to_type::<Template>(matches.value_of("TEMPLATE")) {
             Template::Module | Template::Test | Template::Mkshell => {
-                assert(false, "--by-name cannot be used with the 'module', 'test', or 'mkshell' templates");
+                assert(
+                    false,
+                    "--by-name cannot be used with the 'module', 'test', or 'mkshell' templates",
+                );
             }
             _ => {}
         }
@@ -376,8 +383,8 @@ pub fn validate_and_serialize_matches(
 
     // Dependency hash prefetching is on by default when --from-url is provided.
     // Users can disable via --skip-vendor-hashes.
-    let should_prefetch_hashes = matches.is_present("from-url")
-        && !matches.is_present("skip-vendor-hashes");
+    let should_prefetch_hashes =
+        matches.is_present("from-url") && !matches.is_present("skip-vendor-hashes");
     if should_prefetch_hashes {
         if let Some(hash) = prefetch_dependency_hash(&info) {
             match &info.template {
@@ -394,8 +401,7 @@ pub fn validate_and_serialize_matches(
 
     // Inference is on by default for the rust, go, ruby, stdenv, and stdenvNoCC
     // templates whenever we have a real source to inspect. Users can disable via `--skip-infer-deps`.
-    let infer_enabled = matches.is_present("from-url")
-        && !matches.is_present("skip-infer-deps");
+    let infer_enabled = matches.is_present("from-url") && !matches.is_present("skip-infer-deps");
     if infer_enabled {
         match &info.template {
             Template::Rust(_) => {
@@ -449,13 +455,14 @@ pub fn validate_and_serialize_matches(
     // The path may be rewritten downstream when one of the --init-* flags
     // triggers the structured nix/ layout. Skip the existence check in
     // that case; main.rs re-checks each artefact before writing.
-    let init_will_rewrite_path = matches.is_present("init-flake")
-        || matches.is_present("init-npins");
+    let init_will_rewrite_path =
+        matches.is_present("init-flake") || matches.is_present("init-npins");
     assert(
-        matches.is_present("stdout")
-            || init_will_rewrite_path
-            || !path_to_write.exists(),
-        &format!("Cannot write to file '{}', already exists", path_to_write.display()),
+        matches.is_present("stdout") || init_will_rewrite_path || !path_to_write.exists(),
+        &format!(
+            "Cannot write to file '{}', already exists",
+            path_to_write.display()
+        ),
     );
 
     info
@@ -607,7 +614,13 @@ mod tests {
 
     #[test]
     fn test_url() {
-        let m = build_cli().get_matches_from(vec!["nix-template", "python_package", "-u", "https://pypi.org/project/requests/", "--by-name"]);
+        let m = build_cli().get_matches_from(vec![
+            "nix-template",
+            "python_package",
+            "-u",
+            "https://pypi.org/project/requests/",
+            "--by-name",
+        ]);
         assert_eq!(m.is_present("stdout"), false);
         assert_eq!(m.is_present("by-name"), true);
         assert_eq!(m.occurrences_of("from-url"), 1);

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -55,6 +55,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     let mut local_go_vendor_null = false;
     let mut local_go_module_path = String::new();
     let mut local_python_format: Option<String> = None;
+    let mut local_python_propagated_deps: Vec<String> = Vec::new();
 
     let (detected_candidates, inferred_deps) = if is_init_mode {
         let cwd = std::env::current_dir().unwrap_or_default();
@@ -135,6 +136,10 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                 crate::types::Template::ruby => {
                     crate::deps::ruby::infer_ruby_dependencies_from_path(&cwd)
                         .unwrap_or_else(|| (Vec::new(), Vec::new()))
+                }
+                crate::types::Template::python_package | crate::types::Template::python_application => {
+                    local_python_propagated_deps = crate::deps::python::infer_python_dependencies_from_path(&cwd);
+                    (Vec::new(), Vec::new())
                 }
                 _ => (Vec::new(), Vec::new()),
             }
@@ -237,6 +242,9 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     }
     if let Some(fmt) = local_python_format {
         info.python_format = fmt;
+    }
+    if !local_python_propagated_deps.is_empty() {
+        info.propagated_build_inputs = local_python_propagated_deps;
     }
 
     // ----------------------------------------------------------------

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,7 +1,15 @@
-use crate::{cli, expression, file_path::NixDirLayout, interactive, output, types::{Template, UserConfig}};
+use crate::{
+    cli, expression,
+    file_path::NixDirLayout,
+    interactive, output,
+    types::{Template, UserConfig},
+};
 
-pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_config: Option<&UserConfig>) {
-
+pub fn run(
+    matches: &clap::ArgMatches,
+    _xdg_dirs: &xdg::BaseDirectories,
+    user_config: Option<&UserConfig>,
+) {
     // ----------------------------------------------------------------
     // Init mode detection: --init-flake and --init-npins are special
     // modes that initialize the current directory as a Nix project.
@@ -35,10 +43,12 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
         std::env::current_dir()
             .ok()
             .and_then(|cwd| cwd.file_name().map(|n| n.to_owned()))
-            .and_then(|n| n.to_str().map(|s| {
-                // Convert to kebab-case: lowercase, replace _ and spaces with -
-                s.to_lowercase().replace('_', "-").replace(' ', "-")
-            }))
+            .and_then(|n| {
+                n.to_str().map(|s| {
+                    // Convert to kebab-case: lowercase, replace _ and spaces with -
+                    s.to_lowercase().replace('_', "-").replace(' ', "-")
+                })
+            })
             .unwrap_or_else(|| "my-project".to_owned())
     } else {
         String::new()
@@ -112,7 +122,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                         );
                     }
                 }
-                crate::types::Template::Python(_) | crate::types::Template::Python(_) => {
+                crate::types::Template::Python(_) => {
                     let fmt = crate::detect::detect_python_format(&cwd);
                     eprintln!("Detected Python build format: {}", fmt);
                     local_python_format = Some(fmt);
@@ -137,8 +147,9 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                     crate::deps::ruby::infer_ruby_dependencies_from_path(&cwd)
                         .unwrap_or_else(|| (Vec::new(), Vec::new()))
                 }
-                crate::types::Template::Python(_) | crate::types::Template::Python(_) => {
-                    local_python_propagated_deps = crate::deps::python::infer_python_dependencies_from_path(&cwd);
+                crate::types::Template::Python(_) => {
+                    local_python_propagated_deps =
+                        crate::deps::python::infer_python_dependencies_from_path(&cwd);
                     (Vec::new(), Vec::new())
                 }
                 _ => (Vec::new(), Vec::new()),
@@ -182,7 +193,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                 detected_candidates,
                 Some(directory_name.clone()),
                 Some(inferred_deps),
-                true,  // is_local_init
+                true, // is_local_init
             )
         } else {
             interactive::run_interactive_mode(None, user_config)
@@ -190,10 +201,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
 
         match interactive_result {
             Ok(interactive_data) => {
-                cli::build_expression_info_from_interactive(
-                    interactive_data,
-                    user_config,
-                )
+                cli::build_expression_info_from_interactive(interactive_data, user_config)
             }
             Err(e) => {
                 eprintln!("Interactive mode cancelled or failed: {}", e);
@@ -210,7 +218,8 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
             cli_info.fetcher = crate::types::Fetcher::local;
 
             // Use detected template if not explicitly set
-            if cli_info.template == crate::types::Template::Auto && !detected_candidates.is_empty() {
+            if cli_info.template == crate::types::Template::Auto && !detected_candidates.is_empty()
+            {
                 cli_info.template = detected_candidates[0].template.clone();
             }
 
@@ -273,8 +282,8 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     //   - Never when --by-name is in play (it has its own canonical
     //     placement under nixpkgs).
     let nixpkgs_layout_active = matches.is_present("by-name");
-    let use_structured_layout = !nixpkgs_layout_active
-        && (init_npins || (init_flake && no_path_given));
+    let use_structured_layout =
+        !nixpkgs_layout_active && (init_npins || (init_flake && no_path_given));
 
     // Compute the structured layout up front so every downstream
     // step (path rewrite, overlay, top-level wrappers, flake) can
@@ -364,11 +373,7 @@ for the npins wrapper."
                 .unwrap_or("default.nix");
             Some((
                 flake_path,
-                expression::generate_flake_nix(
-                    &info.template,
-                    output_filename,
-                    directory_name,
-                ),
+                expression::generate_flake_nix(&info.template, output_filename, directory_name),
             ))
         }
     } else {
@@ -376,14 +381,12 @@ for the npins wrapper."
     };
 
     // ----- overlay.nix payload (structured layout only) -----
-    let overlay_payload: Option<(std::path::PathBuf, String)> = layout
-        .as_ref()
-        .map(|l| {
-            (
-                l.overlay_path.clone(),
-                expression::generate_overlay_nix(&info.template, &info.pname),
-            )
-        });
+    let overlay_payload: Option<(std::path::PathBuf, String)> = layout.as_ref().map(|l| {
+        (
+            l.overlay_path.clone(),
+            expression::generate_overlay_nix(&info.template, &info.pname),
+        )
+    });
 
     // ----- top-level default.nix payload (structured layout only) -----
     // Emitted whenever --init-npins is in play, so that non-flake
@@ -445,10 +448,8 @@ for the npins wrapper."
                 .unwrap_or("package.nix")
                 .to_string();
 
-            let wrapper_content = expression::generate_npins_wrapper_default_nix(
-                &info.template,
-                &package_basename,
-            );
+            let wrapper_content =
+                expression::generate_npins_wrapper_default_nix(&info.template, &package_basename);
 
             Some((
                 npins_dir,
@@ -486,15 +487,9 @@ for the npins wrapper."
             legacy_wrapper,
         )) = &npins_payload
         {
-            println!(
-                "\n# ===== {} =====\n",
-                npins_default_path.display()
-            );
+            println!("\n# ===== {} =====\n", npins_default_path.display());
             println!("{}", npins_default_content);
-            println!(
-                "\n# ===== {} =====\n",
-                npins_sources_path.display()
-            );
+            println!("\n# ===== {} =====\n", npins_sources_path.display());
             println!("{}", npins_sources_content);
             if let Some((wrapper_path, wrapper_content)) = legacy_wrapper {
                 println!("\n# ===== {} =====\n", wrapper_path.display());
@@ -568,13 +563,14 @@ for the npins wrapper."
                 .parent()
                 .map(|p| {
                     let s = p.display().to_string();
-                    if s.is_empty() { ".".to_string() } else { s }
+                    if s.is_empty() {
+                        ".".to_string()
+                    } else {
+                        s
+                    }
                 })
                 .unwrap_or_else(|| ".".into());
-            println!(
-                "  1. cd into {} (if not already there)",
-                project_dir
-            );
+            println!("  1. cd into {} (if not already there)", project_dir);
             println!("  2. Pin nixpkgs:  npins add channel --name nixpkgs nixpkgs-unstable");
             println!("  3. Build:        nix-build");
             println!();

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -80,7 +80,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
         // Detect builder variants for local development
         if let Some(candidate) = candidates.first() {
             match candidate.template {
-                crate::types::Template::rust => {
+                crate::types::Template::Rust(_) => {
                     local_use_cargo_lock_file = true;
                     // Scan Cargo.lock for git dependencies that need outputHashes
                     let lock_path = cwd.join("Cargo.lock");
@@ -95,7 +95,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                         }
                     }
                 }
-                crate::types::Template::go => {
+                crate::types::Template::Go(_) => {
                     if cwd.join("vendor").is_dir() {
                         eprintln!("Detected vendor/ directory; using vendorHash = null");
                         local_go_vendor_null = true;
@@ -104,7 +104,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                         local_go_module_path = module;
                     }
                 }
-                crate::types::Template::ruby => {
+                crate::types::Template::Ruby => {
                     if !cwd.join("gemset.nix").exists() {
                         eprintln!(
                             "Warning: gemset.nix not found. Run 'bundix' to generate it \
@@ -112,7 +112,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                         );
                     }
                 }
-                crate::types::Template::python_package | crate::types::Template::python_application => {
+                crate::types::Template::Python(_) | crate::types::Template::Python(_) => {
                     let fmt = crate::detect::detect_python_format(&cwd);
                     eprintln!("Detected Python build format: {}", fmt);
                     local_python_format = Some(fmt);
@@ -125,19 +125,19 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
         // We try both template-specific inference AND build system inference
         let mut deps = if let Some(candidate) = candidates.first() {
             match candidate.template {
-                crate::types::Template::rust => {
+                crate::types::Template::Rust(_) => {
                     crate::deps::rust::infer_rust_dependencies_from_path(&cwd)
                         .unwrap_or_else(|| (Vec::new(), Vec::new()))
                 }
-                crate::types::Template::go => {
+                crate::types::Template::Go(_) => {
                     crate::deps::go::infer_go_dependencies_from_path(&cwd)
                         .unwrap_or_else(|| (Vec::new(), Vec::new()))
                 }
-                crate::types::Template::ruby => {
+                crate::types::Template::Ruby => {
                     crate::deps::ruby::infer_ruby_dependencies_from_path(&cwd)
                         .unwrap_or_else(|| (Vec::new(), Vec::new()))
                 }
-                crate::types::Template::python_package | crate::types::Template::python_application => {
+                crate::types::Template::Python(_) | crate::types::Template::Python(_) => {
                     local_python_propagated_deps = crate::deps::python::infer_python_dependencies_from_path(&cwd);
                     (Vec::new(), Vec::new())
                 }
@@ -210,7 +210,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
             cli_info.fetcher = crate::types::Fetcher::local;
 
             // Use detected template if not explicitly set
-            if cli_info.template == crate::types::Template::auto && !detected_candidates.is_empty() {
+            if cli_info.template == crate::types::Template::Auto && !detected_candidates.is_empty() {
                 cli_info.template = detected_candidates[0].template.clone();
             }
 
@@ -293,7 +293,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     // For module templates the package_path is unused; we redirect
     // info.path_to_write to the module file under nix/modules/.
     if let Some(ref l) = layout {
-        if info.template == Template::module {
+        if info.template == Template::Module {
             if let Some(ref module_path) = l.module_path {
                 info.path_to_write = module_path.clone();
             }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -53,6 +53,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     let mut local_use_cargo_lock_file = false;
     let mut local_cargo_lock_git_deps: Vec<String> = Vec::new();
     let mut local_go_vendor_null = false;
+    let mut local_go_module_path = String::new();
     let mut local_python_format: Option<String> = None;
 
     let (detected_candidates, inferred_deps) = if is_init_mode {
@@ -97,6 +98,9 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                     if cwd.join("vendor").is_dir() {
                         eprintln!("Detected vendor/ directory; using vendorHash = null");
                         local_go_vendor_null = true;
+                    }
+                    if let Some(module) = crate::deps::go::parse_go_mod_module(&cwd) {
+                        local_go_module_path = module;
                     }
                 }
                 crate::types::Template::ruby => {
@@ -227,6 +231,9 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     }
     if local_go_vendor_null {
         info.vendor_hash = crate::types::VENDOR_HASH_NULL.to_owned();
+    }
+    if !local_go_module_path.is_empty() {
+        info.go_module_path = local_go_module_path;
     }
     if let Some(fmt) = local_python_format {
         info.python_format = fmt;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -51,6 +51,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     // `local_go_vendor_null`: Go local mode with vendor/ uses vendorHash = null
     // `local_python_format`: Python format auto-detected from pyproject.toml
     let mut local_use_cargo_lock_file = false;
+    let mut local_cargo_lock_git_deps: Vec<String> = Vec::new();
     let mut local_go_vendor_null = false;
     let mut local_python_format: Option<String> = None;
 
@@ -79,11 +80,31 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
             match candidate.template {
                 crate::types::Template::rust => {
                     local_use_cargo_lock_file = true;
+                    // Scan Cargo.lock for git dependencies that need outputHashes
+                    let lock_path = cwd.join("Cargo.lock");
+                    if let Ok(lock_content) = std::fs::read_to_string(&lock_path) {
+                        local_cargo_lock_git_deps =
+                            crate::deps::rust::parse_cargo_lock_git_deps(&lock_content);
+                        if !local_cargo_lock_git_deps.is_empty() {
+                            eprintln!(
+                                "Detected {} git dependencies in Cargo.lock requiring outputHashes",
+                                local_cargo_lock_git_deps.len()
+                            );
+                        }
+                    }
                 }
                 crate::types::Template::go => {
                     if cwd.join("vendor").is_dir() {
                         eprintln!("Detected vendor/ directory; using vendorHash = null");
                         local_go_vendor_null = true;
+                    }
+                }
+                crate::types::Template::ruby => {
+                    if !cwd.join("gemset.nix").exists() {
+                        eprintln!(
+                            "Warning: gemset.nix not found. Run 'bundix' to generate it \
+                             (required by bundlerApp)."
+                        );
                     }
                 }
                 crate::types::Template::python_package | crate::types::Template::python_application => {
@@ -202,6 +223,7 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
     // Apply local development builder variants detected above.
     if local_use_cargo_lock_file {
         info.use_cargo_lock_file = true;
+        info.cargo_lock_git_deps = local_cargo_lock_git_deps;
     }
     if local_go_vendor_null {
         info.vendor_hash = crate::types::VENDOR_HASH_NULL.to_owned();

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -44,7 +44,16 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
         String::new()
     };
 
-    // Auto-detect template and infer dependencies from local directory
+    // Auto-detect template, infer dependencies, and detect builder
+    // variants from local directory.
+    //
+    // `local_use_cargo_lock_file`: Rust local mode uses cargoLock.lockFile
+    // `local_go_vendor_null`: Go local mode with vendor/ uses vendorHash = null
+    // `local_python_format`: Python format auto-detected from pyproject.toml
+    let mut local_use_cargo_lock_file = false;
+    let mut local_go_vendor_null = false;
+    let mut local_python_format: Option<String> = None;
+
     let (detected_candidates, inferred_deps) = if is_init_mode {
         let cwd = std::env::current_dir().unwrap_or_default();
 
@@ -62,6 +71,27 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
                         .collect::<Vec<_>>()
                         .join(", ")
                 );
+            }
+        }
+
+        // Detect builder variants for local development
+        if let Some(candidate) = candidates.first() {
+            match candidate.template {
+                crate::types::Template::rust => {
+                    local_use_cargo_lock_file = true;
+                }
+                crate::types::Template::go => {
+                    if cwd.join("vendor").is_dir() {
+                        eprintln!("Detected vendor/ directory; using vendorHash = null");
+                        local_go_vendor_null = true;
+                    }
+                }
+                crate::types::Template::python_package | crate::types::Template::python_application => {
+                    let fmt = crate::detect::detect_python_format(&cwd);
+                    eprintln!("Detected Python build format: {}", fmt);
+                    local_python_format = Some(fmt);
+                }
+                _ => {}
             }
         }
 
@@ -168,6 +198,17 @@ pub fn run(matches: &clap::ArgMatches, _xdg_dirs: &xdg::BaseDirectories, user_co
 
         cli_info
     };
+
+    // Apply local development builder variants detected above.
+    if local_use_cargo_lock_file {
+        info.use_cargo_lock_file = true;
+    }
+    if local_go_vendor_null {
+        info.vendor_hash = crate::types::VENDOR_HASH_NULL.to_owned();
+    }
+    if let Some(fmt) = local_python_format {
+        info.python_format = fmt;
+    }
 
     // ----------------------------------------------------------------
     // Init-flag bookkeeping. We support three orthogonal init flags:

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -48,7 +48,6 @@ pub fn run(
     }
 
     // write config
-    std::fs::write(&config_path, toml::to_string(&user_config).unwrap()).unwrap_or_else(
-        |_| panic!("Was unable to write to file: {}", &config_path.display()),
-    );
+    std::fs::write(&config_path, toml::to_string(&user_config).unwrap())
+        .unwrap_or_else(|_| panic!("Was unable to write to file: {}", &config_path.display()));
 }

--- a/src/deps/buildsystem.rs
+++ b/src/deps/buildsystem.rs
@@ -80,7 +80,9 @@ fn lookup_cmake_package(name: &str) -> Option<(&'static [&'static str], &'static
 /// Static mapping from Meson dependency name to nixpkgs equivalent.
 ///
 /// Meson uses pkg-config names, so these map more directly.
-fn lookup_meson_dependency(name: &str) -> Option<(&'static [&'static str], &'static [&'static str])> {
+fn lookup_meson_dependency(
+    name: &str,
+) -> Option<(&'static [&'static str], &'static [&'static str])> {
     match name {
         // Core libraries (pkg-config names)
         "zlib" => Some((&["zlib"], &[])),
@@ -163,8 +165,7 @@ pub fn parse_meson_dependencies(meson_content: &str) -> Vec<String> {
     let mut deps = BTreeSet::new();
 
     // Regex for dependency('name') or dependency("name")
-    let re = Regex::new(r#"dependency\s*\(\s*['"]([a-zA-Z0-9_+\-\.]+)['"]"#)
-        .expect("valid regex");
+    let re = Regex::new(r#"dependency\s*\(\s*['"]([a-zA-Z0-9_+\-\.]+)['"]"#).expect("valid regex");
 
     for cap in re.captures_iter(meson_content) {
         if let Some(dep_name) = cap.get(1) {
@@ -287,8 +288,7 @@ pub fn infer_buildsystem_dependencies_from_path(
 /// Infer build system dependencies from an already-materialized source in ExpressionInfo.
 /// This is the original function used when inferring from remote sources.
 pub fn infer_buildsystem_dependencies(info: &mut ExpressionInfo) -> bool {
-    if let Some((build_inputs, native_build_inputs)) =
-        infer_from_source_path(&info.top_level_path)
+    if let Some((build_inputs, native_build_inputs)) = infer_from_source_path(&info.top_level_path)
     {
         info.build_inputs.extend(build_inputs);
         info.native_build_inputs.extend(native_build_inputs);

--- a/src/deps/buildsystem.rs
+++ b/src/deps/buildsystem.rs
@@ -446,6 +446,7 @@ find_package(OpenSSL)
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
             cargo_lock_git_deps: Vec::new(),
+            go_module_path: String::new(),
             python_format: "setuptools".to_owned(),
         };
 

--- a/src/deps/buildsystem.rs
+++ b/src/deps/buildsystem.rs
@@ -444,6 +444,8 @@ find_package(OpenSSL)
             domain: "".to_owned(),
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
+            use_cargo_lock_file: false,
+            python_format: "setuptools".to_owned(),
         };
 
         let detected = infer_buildsystem_dependencies(&mut info);

--- a/src/deps/buildsystem.rs
+++ b/src/deps/buildsystem.rs
@@ -425,7 +425,7 @@ find_package(OpenSSL)
             license: "mit".to_owned(),
             maintainer: "me".to_owned(),
             fetcher: Fetcher::github,
-            template: Template::stdenv,
+            template: Template::stdenv(),
             path_to_write: PathBuf::new(),
             top_level_path: temp_dir.clone(),
             include_documentation_links: false,

--- a/src/deps/buildsystem.rs
+++ b/src/deps/buildsystem.rs
@@ -445,6 +445,7 @@ find_package(OpenSSL)
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
+            cargo_lock_git_deps: Vec::new(),
             python_format: "setuptools".to_owned(),
         };
 

--- a/src/deps/go.rs
+++ b/src/deps/go.rs
@@ -19,7 +19,7 @@
 //! well-known system libraries, and users can edit the generated
 //! expression to add anything we missed.
 
-use crate::types::{ExpressionInfo, Template};
+use crate::types::ExpressionInfo;
 use log::debug;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -518,7 +518,8 @@ mod tests {
     #[test]
     fn map_unknown_tokens_drop_silently() {
         let mut d = CgoDirectives::default();
-        d.pkg_config_tokens.insert("totally-fictional-lib".to_owned());
+        d.pkg_config_tokens
+            .insert("totally-fictional-lib".to_owned());
         d.ld_libs.insert("notreal".to_owned());
         let (bi, nbi) = map_cgo_to_nix(&d);
         // pkg-config still gets added because there *was* a pkg-config

--- a/src/deps/go.rs
+++ b/src/deps/go.rs
@@ -401,7 +401,7 @@ pub fn infer_go_dependencies_from_path(source_path: &Path) -> Option<(Vec<String
 /// Top-level entry point for remote sources: materialise the source into the
 /// Nix store, then delegate to the core inference logic.
 pub fn infer_go_dependencies(info: &ExpressionInfo) -> Option<(Vec<String>, Vec<String>)> {
-    if info.template != Template::go {
+    if !info.template.is_go() {
         return None;
     }
 

--- a/src/deps/go.rs
+++ b/src/deps/go.rs
@@ -373,6 +373,26 @@ fn infer_from_source_path(source_path: &Path) -> Option<(Vec<String>, Vec<String
 
 /// Infer Go dependencies from a local path (for --init-flake/--init-npins).
 /// This skips the materialisation step and directly scans the given path.
+/// Extract the module path from a `go.mod` file.
+///
+/// Parses the `module` directive (e.g., `module github.com/user/repo`) and
+/// returns the full module path. Used to generate `ldflags` for embedding
+/// version information at build time.
+pub fn parse_go_mod_module(source_path: &Path) -> Option<String> {
+    let go_mod_path = source_path.join("go.mod");
+    let content = std::fs::read_to_string(&go_mod_path).ok()?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("module ") {
+            let module = trimmed["module ".len()..].trim();
+            if !module.is_empty() {
+                return Some(module.to_owned());
+            }
+        }
+    }
+    None
+}
+
 pub fn infer_go_dependencies_from_path(source_path: &Path) -> Option<(Vec<String>, Vec<String>)> {
     eprintln!("Scanning local Go sources for CGO directives...");
     infer_from_source_path(source_path)
@@ -567,5 +587,25 @@ func Foo() {}
         assert!(d.pkg_config_tokens.contains("libssl"));
         assert!(!d.pkg_config_tokens.contains("libsqlite3"));
         assert!(!d.ld_libs.contains("pcap"));
+    }
+
+    #[test]
+    fn parse_go_mod_module_extracts_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("go.mod"),
+            "module github.com/user/myapp\n\ngo 1.21\n",
+        )
+        .unwrap();
+        assert_eq!(
+            parse_go_mod_module(dir.path()),
+            Some("github.com/user/myapp".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_go_mod_module_none_when_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert_eq!(parse_go_mod_module(dir.path()), None);
     }
 }

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -1,4 +1,5 @@
 pub mod buildsystem;
 pub mod go;
+pub mod python;
 pub mod ruby;
 pub mod rust;

--- a/src/deps/python.rs
+++ b/src/deps/python.rs
@@ -201,7 +201,7 @@ pub fn infer_python_dependencies_from_path(source_path: &Path) -> Vec<String> {
 /// Infer `propagatedBuildInputs` from a materialised remote source.
 pub fn infer_python_dependencies(info: &crate::types::ExpressionInfo) -> Vec<String> {
     match info.template {
-        crate::types::Template::python_package | crate::types::Template::python_application => {}
+        crate::types::Template::Python(_) | crate::types::Template::Python(_) => {}
         _ => return Vec::new(),
     }
 

--- a/src/deps/python.rs
+++ b/src/deps/python.rs
@@ -1,0 +1,360 @@
+//! Inference of Python package dependencies from `pyproject.toml`.
+//!
+//! This module reads a Python project's `pyproject.toml`, walks the
+//! `[project.dependencies]` (PEP 621) or `[tool.poetry.dependencies]`
+//! tables, and maps each dependency to its nixpkgs `python3Packages`
+//! attribute name for use in `propagatedBuildInputs`.
+//!
+//! The mapping normalises PyPI names to nixpkgs conventions (lowercase,
+//! hyphens to underscores) and uses a static override table for packages
+//! whose nixpkgs name diverges from the PyPI name.
+//!
+//! As with the Rust and Go modules, the mapping is best-effort: users
+//! can edit the generated expression to add anything we missed.
+
+use log::debug;
+use std::collections::BTreeSet;
+use std::path::Path;
+use toml::Value;
+
+const LOG_TARGET: &str = "nix-template::python_deps";
+
+/// Normalise a PyPI package name to the most likely nixpkgs
+/// `python3Packages` attribute name.
+///
+/// PyPI names are case-insensitive and treat `-`, `_`, and `.` as
+/// equivalent (PEP 503). nixpkgs conventionally lowercases and uses
+/// hyphens, though some older packages use underscores.
+fn normalise_pypi_name(name: &str) -> String {
+    name.to_lowercase()
+        .replace('_', "-")
+        .replace('.', "-")
+}
+
+/// Static overrides for PyPI names whose nixpkgs attribute diverges
+/// from the normalised form. Returns `None` when the normalised name
+/// is correct as-is.
+fn lookup_override(normalised: &str) -> Option<&'static str> {
+    match normalised {
+        // PIL / Pillow
+        "pillow" => Some("pillow"),
+        // PyYAML
+        "pyyaml" => Some("pyyaml"),
+        // python-dateutil
+        "python-dateutil" => Some("python-dateutil"),
+        // scikit-learn
+        "scikit-learn" => Some("scikit-learn"),
+        // beautifulsoup4
+        "beautifulsoup4" => Some("beautifulsoup4"),
+        // opencv-python -> opencv4 (system dep, not a python package in nixpkgs)
+        "opencv-python" | "opencv-python-headless" => Some("opencv4"),
+        // google-cloud packages
+        "google-auth" => Some("google-auth"),
+        "google-api-python-client" => Some("google-api-python-client"),
+        // attrs (the package is just "attrs" in nixpkgs too)
+        "attrs" => Some("attrs"),
+        // importlib-metadata
+        "importlib-metadata" => Some("importlib-metadata"),
+        // typing-extensions
+        "typing-extensions" => Some("typing-extensions"),
+        _ => None,
+    }
+}
+
+/// Well-known packages to skip — they are part of the Python standard
+/// library and don't need to appear in `propagatedBuildInputs`.
+fn is_stdlib(normalised: &str) -> bool {
+    matches!(
+        normalised,
+        "pip"
+            | "setuptools"
+            | "wheel"
+            | "build"
+            | "flit"
+            | "flit-core"
+            | "poetry"
+            | "poetry-core"
+            | "hatchling"
+            | "hatch"
+            | "maturin"
+            | "pdm"
+            | "pdm-backend"
+    )
+}
+
+/// Extract the package name from a PEP 508 dependency string.
+///
+/// Examples:
+/// - `"requests>=2.0"` → `"requests"`
+/// - `"numpy[extra] ; python_version >= '3.8'"` → `"numpy"`
+/// - `"my-pkg"` → `"my-pkg"`
+fn extract_package_name(dep_spec: &str) -> &str {
+    let s = dep_spec.trim();
+    // Name ends at the first version specifier, extra marker, or whitespace
+    let end = s
+        .find(|c: char| c == '>' || c == '<' || c == '=' || c == '!' || c == ';' || c == '[' || c == ' ')
+        .unwrap_or(s.len());
+    s[..end].trim()
+}
+
+/// Parse `[project.dependencies]` (PEP 621 format) from a parsed
+/// `pyproject.toml` value and return the dependency names.
+fn parse_pep621_deps(parsed: &Value) -> Vec<String> {
+    parsed
+        .get("project")
+        .and_then(|p| p.get("dependencies"))
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| extract_package_name(s).to_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parse `[tool.poetry.dependencies]` from a parsed `pyproject.toml`
+/// value and return the dependency names. Skips `python` itself.
+fn parse_poetry_deps(parsed: &Value) -> Vec<String> {
+    parsed
+        .get("tool")
+        .and_then(|t| t.get("poetry"))
+        .and_then(|p| p.get("dependencies"))
+        .and_then(|d| d.as_table())
+        .map(|tbl| {
+            tbl.keys()
+                .filter(|k| k.as_str() != "python")
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Map a list of raw PyPI dependency names to nixpkgs
+/// `python3Packages` attribute names. Deduplicates and sorts.
+fn map_deps_to_nix(raw_names: &[String]) -> Vec<String> {
+    let mut nix_deps: BTreeSet<String> = BTreeSet::new();
+
+    for name in raw_names {
+        let normalised = normalise_pypi_name(name);
+        if is_stdlib(&normalised) {
+            continue;
+        }
+        let nix_name = lookup_override(&normalised)
+            .map(|s| s.to_owned())
+            .unwrap_or(normalised);
+        nix_deps.insert(nix_name);
+    }
+
+    nix_deps.into_iter().collect()
+}
+
+/// Infer `propagatedBuildInputs` from a local Python project directory.
+///
+/// Reads `pyproject.toml` and extracts dependencies from either PEP 621
+/// `[project.dependencies]` or Poetry `[tool.poetry.dependencies]`.
+/// Returns the list of nixpkgs `python3Packages` attribute names.
+pub fn infer_python_dependencies_from_path(source_path: &Path) -> Vec<String> {
+    let pyproject_path = source_path.join("pyproject.toml");
+    let content = match std::fs::read_to_string(&pyproject_path) {
+        Ok(c) => c,
+        Err(_) => {
+            debug!(target: LOG_TARGET, "no pyproject.toml found");
+            return Vec::new();
+        }
+    };
+
+    let parsed: Value = match content.parse() {
+        Ok(v) => v,
+        Err(e) => {
+            debug!(target: LOG_TARGET, "failed to parse pyproject.toml: {}", e);
+            return Vec::new();
+        }
+    };
+
+    // Try PEP 621 first, fall back to Poetry
+    let raw_deps = {
+        let pep621 = parse_pep621_deps(&parsed);
+        if pep621.is_empty() {
+            parse_poetry_deps(&parsed)
+        } else {
+            pep621
+        }
+    };
+
+    if raw_deps.is_empty() {
+        debug!(target: LOG_TARGET, "no dependencies found in pyproject.toml");
+        return Vec::new();
+    }
+
+    let nix_deps = map_deps_to_nix(&raw_deps);
+    if !nix_deps.is_empty() {
+        eprintln!(
+            "Inferred {} propagatedBuildInputs from pyproject.toml: {:?}",
+            nix_deps.len(),
+            nix_deps,
+        );
+    }
+    nix_deps
+}
+
+/// Infer `propagatedBuildInputs` from a materialised remote source.
+pub fn infer_python_dependencies(info: &crate::types::ExpressionInfo) -> Vec<String> {
+    match info.template {
+        crate::types::Template::python_package | crate::types::Template::python_application => {}
+        _ => return Vec::new(),
+    }
+
+    eprintln!("Materialising source to scan for Python dependencies...");
+    let source_path = match crate::source::materialise_source(info) {
+        Some(p) => p,
+        None => {
+            debug!(target: LOG_TARGET, "failed to materialise source");
+            return Vec::new();
+        }
+    };
+    infer_python_dependencies_from_path(&source_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_dir(pyproject_content: &str) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("pyproject.toml"), pyproject_content).unwrap();
+        dir
+    }
+
+    #[test]
+    fn pep621_basic_dependencies() {
+        let dir = make_dir(
+            r#"
+[project]
+name = "myapp"
+dependencies = [
+    "requests>=2.28",
+    "click",
+    "pyyaml>=6.0",
+]
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert_eq!(deps, vec!["click", "pyyaml", "requests"]);
+    }
+
+    #[test]
+    fn pep621_with_extras_and_markers() {
+        let dir = make_dir(
+            r#"
+[project]
+name = "myapp"
+dependencies = [
+    "numpy[extra]>=1.20",
+    "pandas ; python_version >= '3.8'",
+]
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert_eq!(deps, vec!["numpy", "pandas"]);
+    }
+
+    #[test]
+    fn poetry_dependencies() {
+        let dir = make_dir(
+            r#"
+[tool.poetry]
+name = "myapp"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+requests = "^2.28"
+click = "^8.0"
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert_eq!(deps, vec!["click", "requests"]);
+    }
+
+    #[test]
+    fn skips_build_tools() {
+        let dir = make_dir(
+            r#"
+[project]
+name = "myapp"
+dependencies = [
+    "setuptools",
+    "wheel",
+    "requests",
+]
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert_eq!(deps, vec!["requests"]);
+    }
+
+    #[test]
+    fn normalises_names() {
+        let dir = make_dir(
+            r#"
+[project]
+name = "myapp"
+dependencies = [
+    "Pillow>=9.0",
+    "scikit-learn",
+    "PyYAML",
+]
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert_eq!(deps, vec!["pillow", "pyyaml", "scikit-learn"]);
+    }
+
+    #[test]
+    fn deduplicates() {
+        let dir = make_dir(
+            r#"
+[project]
+name = "myapp"
+dependencies = [
+    "requests",
+    "requests>=2.0",
+]
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert_eq!(deps, vec!["requests"]);
+    }
+
+    #[test]
+    fn no_pyproject_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn no_deps_returns_empty() {
+        let dir = make_dir(
+            r#"
+[project]
+name = "myapp"
+"#,
+        );
+        let deps = infer_python_dependencies_from_path(dir.path());
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn extract_package_name_variants() {
+        assert_eq!(extract_package_name("requests>=2.0"), "requests");
+        assert_eq!(extract_package_name("numpy[extra]"), "numpy");
+        assert_eq!(extract_package_name("pandas ; python_version >= '3.8'"), "pandas");
+        assert_eq!(extract_package_name("  click  "), "click");
+        assert_eq!(extract_package_name("my-pkg"), "my-pkg");
+        assert_eq!(extract_package_name("pkg!=1.0"), "pkg");
+        assert_eq!(extract_package_name("pkg<2"), "pkg");
+    }
+}

--- a/src/deps/python.rs
+++ b/src/deps/python.rs
@@ -26,9 +26,7 @@ const LOG_TARGET: &str = "nix-template::python_deps";
 /// equivalent (PEP 503). nixpkgs conventionally lowercases and uses
 /// hyphens, though some older packages use underscores.
 fn normalise_pypi_name(name: &str) -> String {
-    name.to_lowercase()
-        .replace('_', "-")
-        .replace('.', "-")
+    name.to_lowercase().replace('_', "-").replace('.', "-")
 }
 
 /// Static overrides for PyPI names whose nixpkgs attribute diverges
@@ -92,7 +90,9 @@ fn extract_package_name(dep_spec: &str) -> &str {
     let s = dep_spec.trim();
     // Name ends at the first version specifier, extra marker, or whitespace
     let end = s
-        .find(|c: char| c == '>' || c == '<' || c == '=' || c == '!' || c == ';' || c == '[' || c == ' ')
+        .find(|c: char| {
+            c == '>' || c == '<' || c == '=' || c == '!' || c == ';' || c == '[' || c == ' '
+        })
         .unwrap_or(s.len());
     s[..end].trim()
 }
@@ -201,7 +201,7 @@ pub fn infer_python_dependencies_from_path(source_path: &Path) -> Vec<String> {
 /// Infer `propagatedBuildInputs` from a materialised remote source.
 pub fn infer_python_dependencies(info: &crate::types::ExpressionInfo) -> Vec<String> {
     match info.template {
-        crate::types::Template::Python(_) | crate::types::Template::Python(_) => {}
+        crate::types::Template::Python(_) => {}
         _ => return Vec::new(),
     }
 
@@ -351,7 +351,10 @@ name = "myapp"
     fn extract_package_name_variants() {
         assert_eq!(extract_package_name("requests>=2.0"), "requests");
         assert_eq!(extract_package_name("numpy[extra]"), "numpy");
-        assert_eq!(extract_package_name("pandas ; python_version >= '3.8'"), "pandas");
+        assert_eq!(
+            extract_package_name("pandas ; python_version >= '3.8'"),
+            "pandas"
+        );
         assert_eq!(extract_package_name("  click  "), "click");
         assert_eq!(extract_package_name("my-pkg"), "my-pkg");
         assert_eq!(extract_package_name("pkg!=1.0"), "pkg");

--- a/src/deps/ruby.rs
+++ b/src/deps/ruby.rs
@@ -295,6 +295,7 @@ DEPENDENCIES
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
             cargo_lock_git_deps: Vec::new(),
+            go_module_path: String::new(),
             python_format: "setuptools".to_owned(),
         };
 

--- a/src/deps/ruby.rs
+++ b/src/deps/ruby.rs
@@ -166,9 +166,7 @@ fn infer_from_source_path(source_path: &Path) -> Option<(Vec<String>, Vec<String
 
 /// Infer Ruby gem dependencies from a local source path.
 /// Used during local project initialization (--init-flake/--init-npins).
-pub fn infer_ruby_dependencies_from_path(
-    source_path: &Path,
-) -> Option<(Vec<String>, Vec<String>)> {
+pub fn infer_ruby_dependencies_from_path(source_path: &Path) -> Option<(Vec<String>, Vec<String>)> {
     eprintln!("Scanning local Gemfile.lock for dependencies...");
     infer_from_source_path(source_path)
 }
@@ -176,8 +174,7 @@ pub fn infer_ruby_dependencies_from_path(
 /// Infer Ruby gem dependencies from an already-materialized source in ExpressionInfo.
 /// This is the original function used when inferring from remote sources.
 pub fn infer_dependencies(info: &mut ExpressionInfo) -> bool {
-    if let Some((build_inputs, native_build_inputs)) =
-        infer_from_source_path(&info.top_level_path)
+    if let Some((build_inputs, native_build_inputs)) = infer_from_source_path(&info.top_level_path)
     {
         info.build_inputs.extend(build_inputs);
         info.native_build_inputs.extend(native_build_inputs);

--- a/src/deps/ruby.rs
+++ b/src/deps/ruby.rs
@@ -294,6 +294,7 @@ DEPENDENCIES
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
+            cargo_lock_git_deps: Vec::new(),
             python_format: "setuptools".to_owned(),
         };
 

--- a/src/deps/ruby.rs
+++ b/src/deps/ruby.rs
@@ -274,7 +274,7 @@ DEPENDENCIES
             license: "mit".to_owned(),
             maintainer: "me".to_owned(),
             fetcher: Fetcher::github,
-            template: Template::ruby,
+            template: Template::Ruby,
             path_to_write: PathBuf::new(),
             top_level_path: temp_dir.clone(),
             include_documentation_links: false,

--- a/src/deps/ruby.rs
+++ b/src/deps/ruby.rs
@@ -293,6 +293,8 @@ DEPENDENCIES
             domain: "".to_owned(),
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
+            use_cargo_lock_file: false,
+            python_format: "setuptools".to_owned(),
         };
 
         let success = infer_dependencies(&mut info);

--- a/src/deps/rust.rs
+++ b/src/deps/rust.rs
@@ -297,7 +297,7 @@ pub fn infer_rust_dependencies_from_path(source_path: &Path) -> Option<(Vec<Stri
 /// Top-level entry point for remote sources: materialise the source into the
 /// Nix store, then delegate to the core inference logic.
 pub fn infer_rust_dependencies(info: &ExpressionInfo) -> Option<(Vec<String>, Vec<String>)> {
-    if info.template != Template::rust {
+    if !info.template.is_rust() {
         return None;
     }
 

--- a/src/deps/rust.rs
+++ b/src/deps/rust.rs
@@ -106,6 +106,40 @@ pub fn parse_cargo_lock(cargo_lock: &str) -> Vec<String> {
     names.into_iter().collect()
 }
 
+/// Extract git dependency URLs from a `Cargo.lock` file.
+///
+/// When `cargoLock.lockFile` is used in nixpkgs, any `[[package]]` whose
+/// `source` starts with `"git+"` needs a corresponding entry in
+/// `cargoLock.outputHashes` because crates.io doesn't publish checksums for
+/// git sources.
+///
+/// Returns a deduplicated, sorted list of `"name-version"` keys that need
+/// output hashes.
+pub fn parse_cargo_lock_git_deps(cargo_lock: &str) -> Vec<String> {
+    let parsed: Value = match cargo_lock.parse() {
+        Ok(v) => v,
+        Err(e) => {
+            debug!(target: LOG_TARGET, "failed to parse Cargo.lock for git deps: {}", e);
+            return Vec::new();
+        }
+    };
+
+    let mut git_deps: BTreeSet<String> = BTreeSet::new();
+    if let Some(Value::Array(packages)) = parsed.get("package") {
+        for pkg in packages {
+            let source = pkg.get("source").and_then(|v| v.as_str()).unwrap_or("");
+            if source.starts_with("git+") {
+                let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                let version = pkg.get("version").and_then(|v| v.as_str()).unwrap_or("");
+                if !name.is_empty() && !version.is_empty() {
+                    git_deps.insert(format!("{}-{}", name, version));
+                }
+            }
+        }
+    }
+    git_deps.into_iter().collect()
+}
+
 /// Parse the given `Cargo.toml` text and return a deduplicated list of
 /// direct dependency names (from `[dependencies]`, `[build-dependencies]`,
 /// `[dev-dependencies]` is intentionally *excluded* since it's only used
@@ -513,5 +547,47 @@ version = "0.3.0"
             "pkg-config should be deduplicated, got: {:?}",
             nbi
         );
+    }
+
+    #[test]
+    fn parse_cargo_lock_git_deps_extracts_git_sources() {
+        let lock = r#"
+[[package]]
+name = "demo"
+version = "0.1.0"
+
+[[package]]
+name = "some-git-crate"
+version = "0.3.0"
+source = "git+https://github.com/user/repo?rev=abc123#abc123def456"
+
+[[package]]
+name = "registry-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcd1234"
+
+[[package]]
+name = "another-git"
+version = "0.1.0"
+source = "git+https://github.com/user/other#def789"
+"#;
+        let git_deps = parse_cargo_lock_git_deps(lock);
+        assert_eq!(git_deps, vec!["another-git-0.1.0", "some-git-crate-0.3.0"]);
+    }
+
+    #[test]
+    fn parse_cargo_lock_git_deps_empty_when_no_git() {
+        let lock = r#"
+[[package]]
+name = "demo"
+version = "0.1.0"
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+        assert!(parse_cargo_lock_git_deps(lock).is_empty());
     }
 }

--- a/src/deps/rust.rs
+++ b/src/deps/rust.rs
@@ -10,7 +10,7 @@
 //! mapped. Users can edit the generated expression to add anything we
 //! missed.
 
-use crate::types::{ExpressionInfo, Template};
+use crate::types::ExpressionInfo;
 use log::debug;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -249,8 +249,7 @@ fn infer_from_source_path(source_path: &Path) -> Option<(Vec<String>, Vec<String
         }
     };
 
-    let mut crates: BTreeSet<String> =
-        parse_cargo_dependencies(&manifest).into_iter().collect();
+    let mut crates: BTreeSet<String> = parse_cargo_dependencies(&manifest).into_iter().collect();
     debug!(target: LOG_TARGET, "direct dependencies from Cargo.toml: {:?}", crates);
 
     // Best-effort: scan Cargo.lock for transitive crates. Missing lockfile
@@ -532,8 +531,7 @@ version = "0.9.97"
 name = "libssh2-sys"
 version = "0.3.0"
 "#;
-        let mut crates: BTreeSet<String> =
-            parse_cargo_dependencies(manifest).into_iter().collect();
+        let mut crates: BTreeSet<String> = parse_cargo_dependencies(manifest).into_iter().collect();
         crates.extend(parse_cargo_lock(lock));
         let crate_list: Vec<String> = crates.into_iter().collect();
         let (bi, nbi) = map_crates_to_nix(&crate_list);

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -25,7 +25,11 @@ fn indicators() -> Vec<(&'static str, Template, &'static str)> {
     vec![
         ("Cargo.toml", Template::rust(), "Cargo.toml"),
         ("go.mod", Template::go(), "go.mod"),
-        ("pyproject.toml", Template::python_package(), "pyproject.toml"),
+        (
+            "pyproject.toml",
+            Template::python_package(),
+            "pyproject.toml",
+        ),
         ("setup.py", Template::python_package(), "setup.py"),
         ("setup.cfg", Template::python_package(), "setup.cfg"),
         ("pnpm-lock.yaml", Template::pnpm(), "pnpm-lock.yaml"),
@@ -62,10 +66,7 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
                 continue;
             }
             seen_templates.push(template.clone());
-            candidates.push(Candidate {
-                template,
-                reason,
-            });
+            candidates.push(Candidate { template, reason });
         }
     }
 
@@ -81,9 +82,7 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
 
     // npm/pnpm fallback: if no lockfile was found but package.json exists, use npm.
     // This only runs if neither pnpm-lock.yaml nor package-lock.json were detected.
-    let has_npm_or_pnpm = candidates
-        .iter()
-        .any(|c| c.template.is_node());
+    let has_npm_or_pnpm = candidates.iter().any(|c| c.template.is_node());
 
     if !has_npm_or_pnpm && source_path.join("package.json").exists() {
         candidates.push(Candidate {
@@ -94,9 +93,7 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
 
     // .NET detection: scan for .csproj, .fsproj, or .sln files
     // These files have dynamic names (e.g., MyProject.csproj), so we need to scan the directory.
-    let has_dotnet = candidates
-        .iter()
-        .any(|c| c.template == Template::Dotnet);
+    let has_dotnet = candidates.iter().any(|c| c.template == Template::Dotnet);
 
     if !has_dotnet {
         if let Some(reason) = find_dotnet_project_file(source_path) {
@@ -196,7 +193,10 @@ pub fn detect_python_format(source_path: &Path) -> String {
         if let Some(s) = req.as_str() {
             let lower = s.to_lowercase();
             // Extract package name (before any version specifier)
-            let pkg = lower.split(&['>', '<', '=', '!', ';', '['][..]).next().unwrap_or("");
+            let pkg = lower
+                .split(&['>', '<', '=', '!', ';', '['][..])
+                .next()
+                .unwrap_or("");
             let pkg = pkg.trim();
             match pkg {
                 "flit_core" | "flit" => return "flit".to_owned(),
@@ -322,13 +322,17 @@ mod tests {
         .unwrap();
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::python_package());
+        assert_eq!(candidates[0].template, Template::python_application());
     }
 
     #[test]
     fn detect_multiple_candidates() {
         let dir = make_source_dir(&["Cargo.toml", "pyproject.toml"]);
-        fs::write(dir.path().join("pyproject.toml"), "[project]\nname = \"x\"\n").unwrap();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nname = \"x\"\n",
+        )
+        .unwrap();
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].template, Template::rust());
@@ -338,7 +342,11 @@ mod tests {
     #[test]
     fn deduplicate_python_indicators() {
         let dir = make_source_dir(&["pyproject.toml", "setup.py", "setup.cfg"]);
-        fs::write(dir.path().join("pyproject.toml"), "[project]\nname = \"x\"\n").unwrap();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nname = \"x\"\n",
+        )
+        .unwrap();
         let candidates = detect_template_candidates_from_path(dir.path());
         // Only one python entry despite three indicator files
         assert_eq!(candidates.len(), 1);

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -18,26 +18,28 @@ pub struct Candidate {
     pub reason: &'static str,
 }
 
-/// Indicator files and their associated templates, in priority order.
+/// Indicator files and their associated template constructors, in priority order.
 /// When multiple indicators are present, the priority determines the
 /// non-interactive fallback (first match wins).
-const INDICATORS: &[(&str, Template, &str)] = &[
-    ("Cargo.toml", Template::rust, "Cargo.toml"),
-    ("go.mod", Template::go, "go.mod"),
-    ("pyproject.toml", Template::python_package, "pyproject.toml"),
-    ("setup.py", Template::python_package, "setup.py"),
-    ("setup.cfg", Template::python_package, "setup.cfg"),
-    ("pnpm-lock.yaml", Template::pnpm, "pnpm-lock.yaml"),
-    ("package-lock.json", Template::npm, "package-lock.json"),
-    // Note: package.json is handled separately as a fallback (see below)
-    ("Gemfile.lock", Template::ruby, "Gemfile.lock"),
-    ("Gemfile", Template::ruby, "Gemfile"),
-    ("meson.build", Template::stdenv, "meson.build"),
-    ("CMakeLists.txt", Template::stdenv, "CMakeLists.txt"),
-    ("configure", Template::stdenv, "configure"),
-    ("configure.ac", Template::stdenv, "configure.ac"),
-    ("Makefile", Template::stdenv, "Makefile"),
-];
+fn indicators() -> Vec<(&'static str, Template, &'static str)> {
+    vec![
+        ("Cargo.toml", Template::rust(), "Cargo.toml"),
+        ("go.mod", Template::go(), "go.mod"),
+        ("pyproject.toml", Template::python_package(), "pyproject.toml"),
+        ("setup.py", Template::python_package(), "setup.py"),
+        ("setup.cfg", Template::python_package(), "setup.cfg"),
+        ("pnpm-lock.yaml", Template::pnpm(), "pnpm-lock.yaml"),
+        ("package-lock.json", Template::npm(), "package-lock.json"),
+        // Note: package.json is handled separately as a fallback (see below)
+        ("Gemfile.lock", Template::Ruby, "Gemfile.lock"),
+        ("Gemfile", Template::Ruby, "Gemfile"),
+        ("meson.build", Template::stdenv(), "meson.build"),
+        ("CMakeLists.txt", Template::stdenv(), "CMakeLists.txt"),
+        ("configure", Template::stdenv(), "configure"),
+        ("configure.ac", Template::stdenv(), "configure.ac"),
+        ("Makefile", Template::stdenv(), "Makefile"),
+    ]
+}
 
 /// Scan a directory for build-system indicator files and return template candidates.
 ///
@@ -52,16 +54,16 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
     let mut candidates: Vec<Candidate> = Vec::new();
     let mut seen_templates: Vec<Template> = Vec::new();
 
-    for &(filename, ref template, reason) in INDICATORS {
-        if source_path.join(filename).exists() {
+    for (filename, template, reason) in indicators() {
+        if source_path.join(&filename).exists() {
             // Deduplicate by template type (e.g., setup.py and pyproject.toml
             // both map to python_package — only keep the first).
-            if seen_templates.contains(template) {
+            if seen_templates.contains(&template) {
                 continue;
             }
             seen_templates.push(template.clone());
             candidates.push(Candidate {
-                template: template.clone(),
+                template,
                 reason,
             });
         }
@@ -69,9 +71,9 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
 
     // Python sub-classification: if python was detected, check if it's an application.
     for candidate in candidates.iter_mut() {
-        if candidate.template == Template::python_package {
+        if candidate.template.is_python() {
             if is_python_application(source_path) {
-                candidate.template = Template::python_application;
+                candidate.template = Template::python_application();
             }
             break;
         }
@@ -81,11 +83,11 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
     // This only runs if neither pnpm-lock.yaml nor package-lock.json were detected.
     let has_npm_or_pnpm = candidates
         .iter()
-        .any(|c| c.template == Template::npm || c.template == Template::pnpm);
+        .any(|c| c.template.is_node());
 
     if !has_npm_or_pnpm && source_path.join("package.json").exists() {
         candidates.push(Candidate {
-            template: Template::npm,
+            template: Template::npm(),
             reason: "package.json",
         });
     }
@@ -94,12 +96,12 @@ pub fn detect_template_candidates_from_path(source_path: &Path) -> Vec<Candidate
     // These files have dynamic names (e.g., MyProject.csproj), so we need to scan the directory.
     let has_dotnet = candidates
         .iter()
-        .any(|c| c.template == Template::dotnet);
+        .any(|c| c.template == Template::Dotnet);
 
     if !has_dotnet {
         if let Some(reason) = find_dotnet_project_file(source_path) {
             candidates.push(Candidate {
-                template: Template::dotnet,
+                template: Template::Dotnet,
                 reason,
             });
         }
@@ -137,7 +139,7 @@ pub fn detect_template_candidates(info: &ExpressionInfo) -> Vec<Candidate> {
     // PyPI short-circuit: we know it's Python, just classify package vs application.
     if info.fetcher == Fetcher::pypi {
         return vec![Candidate {
-            template: Template::python_package,
+            template: Template::python_package(),
             reason: "PyPI source",
         }];
     }
@@ -285,7 +287,7 @@ mod tests {
         let dir = make_source_dir(&["Cargo.toml", "src/main.rs"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::rust);
+        assert_eq!(candidates[0].template, Template::rust());
     }
 
     #[test]
@@ -293,7 +295,7 @@ mod tests {
         let dir = make_source_dir(&["go.mod", "main.go"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::go);
+        assert_eq!(candidates[0].template, Template::go());
     }
 
     #[test]
@@ -307,7 +309,7 @@ mod tests {
         .unwrap();
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::python_package);
+        assert_eq!(candidates[0].template, Template::python_package());
     }
 
     #[test]
@@ -320,7 +322,7 @@ mod tests {
         .unwrap();
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::python_application);
+        assert_eq!(candidates[0].template, Template::python_package());
     }
 
     #[test]
@@ -329,8 +331,8 @@ mod tests {
         fs::write(dir.path().join("pyproject.toml"), "[project]\nname = \"x\"\n").unwrap();
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].template, Template::rust);
-        assert_eq!(candidates[1].template, Template::python_package);
+        assert_eq!(candidates[0].template, Template::rust());
+        assert_eq!(candidates[1].template, Template::python_package());
     }
 
     #[test]
@@ -340,7 +342,7 @@ mod tests {
         let candidates = detect_template_candidates_from_path(dir.path());
         // Only one python entry despite three indicator files
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::python_package);
+        assert_eq!(candidates[0].template, Template::python_package());
     }
 
     #[test]
@@ -348,7 +350,7 @@ mod tests {
         let dir = make_source_dir(&["CMakeLists.txt", "src/main.c"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::stdenv);
+        assert_eq!(candidates[0].template, Template::stdenv());
     }
 
     #[test]
@@ -363,7 +365,7 @@ mod tests {
         let dir = make_source_dir(&["package.json", "package-lock.json"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::npm);
+        assert_eq!(candidates[0].template, Template::npm());
         assert_eq!(candidates[0].reason, "package-lock.json");
     }
 
@@ -372,7 +374,7 @@ mod tests {
         let dir = make_source_dir(&["package.json", "pnpm-lock.yaml"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::pnpm);
+        assert_eq!(candidates[0].template, Template::pnpm());
         assert_eq!(candidates[0].reason, "pnpm-lock.yaml");
     }
 
@@ -381,7 +383,7 @@ mod tests {
         let dir = make_source_dir(&["package.json"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::npm);
+        assert_eq!(candidates[0].template, Template::npm());
         assert_eq!(candidates[0].reason, "package.json");
     }
 
@@ -393,7 +395,7 @@ mod tests {
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
         // pnpm-lock.yaml has higher priority in INDICATORS, so it should win
-        assert_eq!(candidates[0].template, Template::pnpm);
+        assert_eq!(candidates[0].template, Template::pnpm());
     }
 
     #[test]
@@ -402,7 +404,7 @@ mod tests {
         let dir = make_source_dir(&["package.json", "package-lock.json"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::npm);
+        assert_eq!(candidates[0].template, Template::npm());
         // package-lock.json has higher priority than package.json
         assert_eq!(candidates[0].reason, "package-lock.json");
     }
@@ -412,8 +414,8 @@ mod tests {
         let dir = make_source_dir(&["Cargo.toml", "package.json"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].template, Template::rust);
-        assert_eq!(candidates[1].template, Template::npm);
+        assert_eq!(candidates[0].template, Template::rust());
+        assert_eq!(candidates[1].template, Template::npm());
     }
 
     #[test]
@@ -421,7 +423,7 @@ mod tests {
         let dir = make_source_dir(&["MyProject.csproj", "Program.cs"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::dotnet);
+        assert_eq!(candidates[0].template, Template::Dotnet);
         assert_eq!(candidates[0].reason, "*.csproj");
     }
 
@@ -430,7 +432,7 @@ mod tests {
         let dir = make_source_dir(&["MyProject.fsproj", "Program.fs"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::dotnet);
+        assert_eq!(candidates[0].template, Template::Dotnet);
         assert_eq!(candidates[0].reason, "*.fsproj");
     }
 
@@ -439,7 +441,7 @@ mod tests {
         let dir = make_source_dir(&["MySolution.sln", "README.md"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::dotnet);
+        assert_eq!(candidates[0].template, Template::Dotnet);
         assert_eq!(candidates[0].reason, "*.sln");
     }
 
@@ -448,8 +450,8 @@ mod tests {
         let dir = make_source_dir(&["Cargo.toml", "MyProject.csproj"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].template, Template::rust);
-        assert_eq!(candidates[1].template, Template::dotnet);
+        assert_eq!(candidates[0].template, Template::rust());
+        assert_eq!(candidates[1].template, Template::Dotnet);
     }
 
     #[test]
@@ -457,7 +459,7 @@ mod tests {
         let dir = make_source_dir(&["Gemfile", "Gemfile.lock", "lib/app.rb"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::ruby);
+        assert_eq!(candidates[0].template, Template::Ruby);
         assert_eq!(candidates[0].reason, "Gemfile.lock");
     }
 
@@ -466,7 +468,7 @@ mod tests {
         let dir = make_source_dir(&["Gemfile", "lib/app.rb"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::ruby);
+        assert_eq!(candidates[0].template, Template::Ruby);
         assert_eq!(candidates[0].reason, "Gemfile");
     }
 
@@ -475,8 +477,8 @@ mod tests {
         let dir = make_source_dir(&["Cargo.toml", "Gemfile"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].template, Template::rust);
-        assert_eq!(candidates[1].template, Template::ruby);
+        assert_eq!(candidates[0].template, Template::rust());
+        assert_eq!(candidates[1].template, Template::Ruby);
     }
 
     #[test]
@@ -485,7 +487,7 @@ mod tests {
         let dir = make_source_dir(&["Gemfile", "Gemfile.lock"]);
         let candidates = detect_template_candidates_from_path(dir.path());
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].template, Template::ruby);
+        assert_eq!(candidates[0].template, Template::Ruby);
         // Gemfile.lock has higher priority than Gemfile
         assert_eq!(candidates[0].reason, "Gemfile.lock");
     }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -200,7 +200,7 @@ pub fn detect_python_format(source_path: &Path) -> String {
                 "flit_core" | "flit" => return "flit".to_owned(),
                 "poetry-core" | "poetry" => return "poetry".to_owned(),
                 "hatchling" | "hatch" => return "hatchling".to_owned(),
-                "maturin" => return "setuptools".to_owned(),
+                "maturin" => return "pyproject".to_owned(),
                 "setuptools" => return "setuptools".to_owned(),
                 _ => {}
             }
@@ -535,14 +535,14 @@ mod tests {
     }
 
     #[test]
-    fn detect_format_maturin_maps_to_setuptools() {
+    fn detect_format_maturin_maps_to_pyproject() {
         let dir = make_source_dir(&["pyproject.toml"]);
         fs::write(
             dir.path().join("pyproject.toml"),
             "[build-system]\nrequires = [\"maturin>=1.0\"]\n",
         )
         .unwrap();
-        assert_eq!(detect_python_format(dir.path()), "setuptools");
+        assert_eq!(detect_python_format(dir.path()), "pyproject");
     }
 
     #[test]

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -154,6 +154,63 @@ pub fn detect_template_candidates(info: &ExpressionInfo) -> Vec<Candidate> {
     detect_template_candidates_from_path(&source_path)
 }
 
+/// Detect the Python build system format from `pyproject.toml`.
+///
+/// Parses `[build-system].requires` to identify the build backend and returns
+/// the corresponding nixpkgs `format` value. Falls back to `"setuptools"` when
+/// detection fails or no pyproject.toml is present.
+pub fn detect_python_format(source_path: &Path) -> String {
+    let pyproject_path = source_path.join("pyproject.toml");
+    if !pyproject_path.is_file() {
+        return "setuptools".to_owned();
+    }
+
+    let content = match std::fs::read_to_string(&pyproject_path) {
+        Ok(c) => c,
+        Err(_) => return "setuptools".to_owned(),
+    };
+
+    let parsed = match content.parse::<toml::Value>() {
+        Ok(v) => v,
+        Err(_) => return "setuptools".to_owned(),
+    };
+
+    // Look at [build-system].requires
+    let requires = parsed
+        .get("build-system")
+        .and_then(|bs| bs.get("requires"))
+        .and_then(|r| r.as_array());
+
+    let requires = match requires {
+        Some(r) => r,
+        None => {
+            // pyproject.toml exists but no [build-system] section
+            return "pyproject".to_owned();
+        }
+    };
+
+    // Check each requirement against known backends
+    for req in requires {
+        if let Some(s) = req.as_str() {
+            let lower = s.to_lowercase();
+            // Extract package name (before any version specifier)
+            let pkg = lower.split(&['>', '<', '=', '!', ';', '['][..]).next().unwrap_or("");
+            let pkg = pkg.trim();
+            match pkg {
+                "flit_core" | "flit" => return "flit".to_owned(),
+                "poetry-core" | "poetry" => return "poetry".to_owned(),
+                "hatchling" | "hatch" => return "hatchling".to_owned(),
+                "maturin" => return "setuptools".to_owned(),
+                "setuptools" => return "setuptools".to_owned(),
+                _ => {}
+            }
+        }
+    }
+
+    // [build-system].requires exists but no known backend matched
+    "pyproject".to_owned()
+}
+
 /// Determine whether a Python project is an application (has entry points /
 /// scripts) or a library (no scripts).
 fn is_python_application(source: &Path) -> bool {
@@ -431,5 +488,77 @@ mod tests {
         assert_eq!(candidates[0].template, Template::ruby);
         // Gemfile.lock has higher priority than Gemfile
         assert_eq!(candidates[0].reason, "Gemfile.lock");
+    }
+
+    #[test]
+    fn detect_format_setuptools() {
+        let dir = make_source_dir(&["pyproject.toml"]);
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[build-system]\nrequires = [\"setuptools>=61.0\"]\n",
+        )
+        .unwrap();
+        assert_eq!(detect_python_format(dir.path()), "setuptools");
+    }
+
+    #[test]
+    fn detect_format_flit() {
+        let dir = make_source_dir(&["pyproject.toml"]);
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[build-system]\nrequires = [\"flit_core>=3.2\"]\n",
+        )
+        .unwrap();
+        assert_eq!(detect_python_format(dir.path()), "flit");
+    }
+
+    #[test]
+    fn detect_format_poetry() {
+        let dir = make_source_dir(&["pyproject.toml"]);
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[build-system]\nrequires = [\"poetry-core>=1.0.0\"]\n",
+        )
+        .unwrap();
+        assert_eq!(detect_python_format(dir.path()), "poetry");
+    }
+
+    #[test]
+    fn detect_format_hatchling() {
+        let dir = make_source_dir(&["pyproject.toml"]);
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[build-system]\nrequires = [\"hatchling\"]\n",
+        )
+        .unwrap();
+        assert_eq!(detect_python_format(dir.path()), "hatchling");
+    }
+
+    #[test]
+    fn detect_format_maturin_maps_to_setuptools() {
+        let dir = make_source_dir(&["pyproject.toml"]);
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[build-system]\nrequires = [\"maturin>=1.0\"]\n",
+        )
+        .unwrap();
+        assert_eq!(detect_python_format(dir.path()), "setuptools");
+    }
+
+    #[test]
+    fn detect_format_no_build_system_returns_pyproject() {
+        let dir = make_source_dir(&["pyproject.toml"]);
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nname = \"mypackage\"\n",
+        )
+        .unwrap();
+        assert_eq!(detect_python_format(dir.path()), "pyproject");
+    }
+
+    #[test]
+    fn detect_format_no_pyproject_returns_setuptools() {
+        let dir = make_source_dir(&["setup.py"]);
+        assert_eq!(detect_python_format(dir.path()), "setuptools");
     }
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,4 @@
-use crate::types::{ExpressionInfo, Fetcher, Template};
+use crate::types::{ExpressionInfo, Fetcher, Template, VENDOR_HASH_NULL};
 
 fn derivation_helper(info: &ExpressionInfo) -> (String, String) {
     let (input, derivation, documentation_key): (&str, &str, Option<&str>) = match info.template {
@@ -96,7 +96,7 @@ fn fetch_block(fetcher: &Fetcher) -> (&'static str, &'static str) {
 fn addtional_pkg_attr_headers(template: &Template) -> &'static str {
     match template {
         Template::python_package | Template::python_application => {
-            "\n  @doc:pythonFormat@format = \"setuptools\";"
+            "\n  @doc:pythonFormat@format = \"@python_format@\";"
         }
         _ => "",
     }
@@ -120,10 +120,20 @@ fn build_inputs(info: &ExpressionInfo) -> String {
             } else {
                 "\n\n  nativeBuildInputs = [@native_build_inputs@ ];".to_owned()
             };
+            // Local development uses cargoLock.lockFile (no hash needed);
+            // remote/nixpkgs packaging uses cargoHash with an SRI hash.
+            // The lockFile path is ../Cargo.lock because the package
+            // expression lives under nix/package.nix in the structured layout.
+            let cargo_block = if info.use_cargo_lock_file {
+                "  cargoLock.lockFile = ../Cargo.lock;".to_owned()
+            } else {
+                "  @doc:cargoHash@cargoHash = \"@cargo_hash@\";".to_owned()
+            };
             format!(
-                "  @doc:cargoHash@cargoHash = \"@cargo_hash@\";{native}
+                "{cargo_block}{native}
 
   @doc:buildDependencies@buildInputs = [@build_inputs@ ];",
+                cargo_block = cargo_block,
                 native = native,
             )
         }
@@ -141,11 +151,19 @@ fn build_inputs(info: &ExpressionInfo) -> String {
             } else {
                 "\n  buildInputs = [@build_inputs@ ];".to_owned()
             };
+            // When vendor/ directory is committed locally, vendorHash = null
+            // (no quotes) tells buildGoModule to skip fetching.
+            let vendor_line = if info.vendor_hash == VENDOR_HASH_NULL {
+                "  @doc:vendorHash@vendorHash = null;".to_owned()
+            } else {
+                "  @doc:vendorHash@vendorHash = \"@vendor_hash@\";".to_owned()
+            };
             format!(
                 "  @doc:buildDependencies@
-  @doc:vendorHash@vendorHash = \"@vendor_hash@\";{native}{build}
+  {vendor_line}{native}{build}
 
   @doc:goSubPackages@subPackages = [ \".\" ];",
+                vendor_line = vendor_line,
                 native = native,
                 build = build,
             )
@@ -415,6 +433,8 @@ mod tests {
             domain: "".to_owned(),
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
+            use_cargo_lock_file: false,
+            python_format: "setuptools".to_owned(),
         }
     }
 
@@ -457,6 +477,8 @@ mod tests {
             domain: "".to_owned(),
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
+            use_cargo_lock_file: false,
+            python_format: "setuptools".to_owned(),
         }
     }
 
@@ -591,6 +613,63 @@ mod tests {
         // can wire them through.
         assert!(out.contains(", pkg-config"), "header missing pkg-config: {}", out);
         assert!(out.contains(", openssl"), "header missing openssl: {}", out);
+    }
+
+    #[test]
+    fn rust_local_mode_uses_cargo_lock_file() {
+        let mut info = rust_info();
+        info.use_cargo_lock_file = true;
+        info.fetcher = Fetcher::local;
+        let expr = generate_expression(&info);
+        let out = info.format(&expr);
+        assert!(
+            out.contains("cargoLock.lockFile = ../Cargo.lock;"),
+            "expected cargoLock.lockFile in:\n{}",
+            out
+        );
+        assert!(
+            !out.contains("cargoHash"),
+            "should not contain cargoHash when using lockFile:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn go_vendor_null_renders_without_quotes() {
+        let mut info = rust_info();
+        info.template = Template::go;
+        info.vendor_hash = "null".to_owned();
+        let expr = generate_expression(&info);
+        let out = info.format(&expr);
+        assert!(
+            out.contains("vendorHash = null;"),
+            "expected vendorHash = null; (no quotes) in:\n{}",
+            out
+        );
+        assert!(
+            !out.contains("vendorHash = \"null\""),
+            "vendorHash = null should not be quoted:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn python_format_renders_detected_format() {
+        let mut info = rust_info();
+        info.template = Template::python_package;
+        info.python_format = "flit".to_owned();
+        let expr = generate_expression(&info);
+        let out = info.format(&expr);
+        assert!(
+            out.contains("format = \"flit\";"),
+            "expected format = \"flit\" in:\n{}",
+            out
+        );
+        assert!(
+            !out.contains("setuptools"),
+            "should not contain setuptools when format is flit:\n{}",
+            out
+        );
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,28 +1,47 @@
-use crate::types::{ExpressionInfo, Fetcher, Template, StdenvVariant, VENDOR_HASH_NULL};
+use crate::types::{ExpressionInfo, Fetcher, StdenvVariant, Template, VENDOR_HASH_NULL};
 
 fn derivation_helper(info: &ExpressionInfo) -> (String, String) {
     let (input, derivation, documentation_key): (&str, &str, Option<&str>) = match &info.template {
-        Template::Auto => unreachable!("'auto' template should be resolved before expression generation"),
-        Template::Stdenv(StdenvVariant::Default) => ("stdenv", "stdenv.mkDerivation", Some("stdenvMkDerivation")),
+        Template::Auto => {
+            unreachable!("'auto' template should be resolved before expression generation")
+        }
+        Template::Stdenv(StdenvVariant::Default) => {
+            ("stdenv", "stdenv.mkDerivation", Some("stdenvMkDerivation"))
+        }
         Template::Stdenv(StdenvVariant::NoCC) => (
             "stdenvNoCC",
             "stdenvNoCC.mkDerivation",
             Some("stdenvNoCCMkDerivation"),
         ),
         // Python library packages use buildPythonPackage; applications use buildPythonApplication
-        Template::Python(config) => {
-            match config.variant {
-                crate::types::PythonVariant::Package => ("buildPythonPackage", "buildPythonPackage", None),
-                crate::types::PythonVariant::Application => ("buildPythonApplication", "buildPythonApplication", None),
+        Template::Python(config) => match config.variant {
+            crate::types::PythonVariant::Package => {
+                ("buildPythonPackage", "buildPythonPackage", None)
             }
-        }
+            crate::types::PythonVariant::Application => {
+                ("buildPythonApplication", "buildPythonApplication", None)
+            }
+        },
         Template::Mkshell => ("pkgs ? import <nixpkgs> {}", "with pkgs;\n\nmkShell", None),
         Template::Go(_) => ("buildGoModule", "buildGoModule", None),
         Template::Rust(_) => ("rustPlatform", "rustPlatform.buildRustPackage", None),
-        Template::Node(_) => ("buildNpmPackage", "buildNpmPackage", Some("buildNpmPackage")),
-        Template::Dotnet => ("buildDotnetModule", "buildDotnetModule", Some("buildDotnetModule")),
+        Template::Node(config) => match config.variant {
+            crate::types::NodeVariant::Npm => (
+                "buildNpmPackage",
+                "buildNpmPackage",
+                Some("buildNpmPackage"),
+            ),
+            crate::types::NodeVariant::Pnpm => {
+                ("stdenv", "stdenv.mkDerivation", Some("stdenvMkDerivation"))
+            }
+        },
+        Template::Dotnet => (
+            "buildDotnetModule",
+            "buildDotnetModule",
+            Some("buildDotnetModule"),
+        ),
         Template::Ruby => ("bundlerApp", "bundlerApp", Some("bundlerApp")),
-        Template::Test => ("", "", None),  // Tests aren't a normal expression
+        Template::Test => ("", "", None), // Tests aren't a normal expression
         Template::Module => ("", "", None), // Modules aren't a normal expression
     };
 
@@ -84,27 +103,22 @@ fn fetch_block(fetcher: &Fetcher) -> (&'static str, &'static str) {
     sha256 = \"@src_sha@\";
   };",
         ),
-        Fetcher::local => (
-            "",
-            "  @doc:fetcher@src = ./..;",
-        ),
+        Fetcher::local => ("", "  @doc:fetcher@src = ./..;"),
     }
 }
 
 fn addtional_pkg_attr_headers(template: &Template) -> &'static str {
     match template {
-        Template::Python(_) => {
-            "\n  @doc:pythonFormat@format = \"@python_format@\";"
-        }
+        Template::Python(_) => "\n  @doc:pythonFormat@format = \"@python_format@\";",
         _ => "",
     }
 }
 
 fn build_inputs(info: &ExpressionInfo) -> String {
-    match info.template {
+    match &info.template {
         // Python applications don't carry a Python-import smoke test the way
         // libraries do; their entry points are exercised at runtime.
-        Template::Python(_) =>
+        Template::Python(config) if config.variant == crate::types::PythonVariant::Application =>
             "  @doc:buildDependencies@propagatedBuildInputs = [@propagated_build_inputs@ ];".to_owned(),
         // Python packages (libraries) include pythonImportsCheck for smoke testing
         Template::Python(_) => "  @doc:buildDependencies@propagatedBuildInputs = [@propagated_build_inputs@ ];
@@ -187,11 +201,13 @@ fn build_inputs(info: &ExpressionInfo) -> String {
                 ldflags = ldflags,
             )
         }
-        Template::Node(_) => {
-            "  npmDepsHash = \"@npm_deps_hash@\";".to_owned()
-        }
-        Template::Node(_) => {
-            "  nativeBuildInputs = [
+        Template::Node(config) => {
+            match config.variant {
+                crate::types::NodeVariant::Npm => {
+                    "  npmDepsHash = \"@npm_deps_hash@\";".to_owned()
+                }
+                crate::types::NodeVariant::Pnpm => {
+                    "  nativeBuildInputs = [
     nodejs
     pnpmConfigHook
     pnpm_10
@@ -203,6 +219,8 @@ fn build_inputs(info: &ExpressionInfo) -> String {
     fetcherVersion = 3;
     hash = \"@pnpm_deps_hash@\";
   };".to_owned()
+                }
+            }
         }
         Template::Dotnet => {
             "  projectFile = \"@project_file@\";\n  nugetDeps = ./deps.json;  # Run `nix-build -A package-name.passthru.fetch-deps` to generate".to_owned()
@@ -563,7 +581,11 @@ mod tests {
             "missing buildInputs in:\n{}",
             out
         );
-        assert!(out.contains(", pkg-config"), "header missing pkg-config: {}", out);
+        assert!(
+            out.contains(", pkg-config"),
+            "header missing pkg-config: {}",
+            out
+        );
         assert!(out.contains(", zlib"), "header missing zlib: {}", out);
     }
 
@@ -578,7 +600,11 @@ mod tests {
         info.native_build_inputs = Vec::new();
         let expr = generate_expression(&info);
         let out = info.format(&expr);
-        assert!(out.contains("buildInputs = [ ];"), "missing placeholder in:\n{}", out);
+        assert!(
+            out.contains("buildInputs = [ ];"),
+            "missing placeholder in:\n{}",
+            out
+        );
         assert!(
             !out.contains("nativeBuildInputs"),
             "should not render nativeBuildInputs without input:\n{}",
@@ -634,7 +660,11 @@ mod tests {
         );
         // The function-header should also list both crates so callPackage
         // can wire them through.
-        assert!(out.contains(", pkg-config"), "header missing pkg-config: {}", out);
+        assert!(
+            out.contains(", pkg-config"),
+            "header missing pkg-config: {}",
+            out
+        );
         assert!(out.contains(", openssl"), "header missing openssl: {}", out);
     }
 
@@ -811,7 +841,8 @@ pub fn generate_flake_nix(template: &Template, output_file: &str, directory_name
         ""
     };
 
-    format!(r#"{{
+    format!(
+        r#"{{
   # This should be the directory name
   description = "{directory}";
 
@@ -842,7 +873,11 @@ pub fn generate_flake_nix(template: &Template, output_file: &str, directory_name
       );
     }};
 }}
-"#, directory = directory_name, inner_attr_path = inner_attr_path, output_file = output_file)
+"#,
+        directory = directory_name,
+        inner_attr_path = inner_attr_path,
+        output_file = output_file
+    )
 }
 
 /// Generate the standardized `nix/overlay.nix` file. The overlay calls
@@ -871,9 +906,7 @@ final: prev: {
     }
 
     let call_package = match template {
-        Template::Python(_) => {
-            "final.python3Packages.callPackage"
-        }
+        Template::Python(_) => "final.python3Packages.callPackage",
         _ => "final.callPackage",
     };
 
@@ -897,7 +930,11 @@ final: prev: {{
 /// otherwise it falls back to the `<nixpkgs>` channel. The wrapper
 /// applies `./nix/overlay.nix` and exposes the package attribute so that
 /// `nix-build` from the project root just works.
-pub fn generate_structured_default_nix(template: &Template, pname: &str, with_npins: bool) -> String {
+pub fn generate_structured_default_nix(
+    template: &Template,
+    pname: &str,
+    with_npins: bool,
+) -> String {
     let nixpkgs_import = if with_npins {
         r#"let
   sources = import ./npins;
@@ -952,7 +989,11 @@ pkgs
 /// Generate a flake.nix that references the standardized `./nix/overlay.nix`
 /// rather than a sibling package file. Pairs with the structured layout
 /// produced by `--init-flake` (with nix/ layout) or `--init-npins`.
-pub fn generate_structured_flake_nix(template: &Template, pname: &str, directory_name: &str) -> String {
+pub fn generate_structured_flake_nix(
+    template: &Template,
+    pname: &str,
+    directory_name: &str,
+) -> String {
     if *template == Template::Module {
         // Module-only flake: expose nixosModules instead of packages.
         return format!(

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -169,14 +169,24 @@ fn build_inputs(info: &ExpressionInfo) -> String {
             } else {
                 "  @doc:vendorHash@vendorHash = \"@vendor_hash@\";".to_owned()
             };
+            // Suggest ldflags when the Go module path is known (local mode).
+            let ldflags = if info.go_module_path.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "\n\n  # ldflags = [ \"-X {module}/main.version=${{finalAttrs.version}}\" ];",
+                    module = info.go_module_path,
+                )
+            };
             format!(
                 "  @doc:buildDependencies@
   {vendor_line}{native}{build}
 
-  @doc:goSubPackages@subPackages = [ \".\" ];",
+  @doc:goSubPackages@subPackages = [ \".\" ];{ldflags}",
                 vendor_line = vendor_line,
                 native = native,
                 build = build,
+                ldflags = ldflags,
             )
         }
         Template::npm => {
@@ -446,6 +456,7 @@ mod tests {
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
             cargo_lock_git_deps: Vec::new(),
+            go_module_path: String::new(),
             python_format: "setuptools".to_owned(),
         }
     }
@@ -491,6 +502,7 @@ mod tests {
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
             cargo_lock_git_deps: Vec::new(),
+            go_module_path: String::new(),
             python_format: "setuptools".to_owned(),
         }
     }
@@ -671,6 +683,35 @@ mod tests {
         assert!(
             out.contains("\"other-crate-0.2.0\" = \"sha256-"),
             "expected other-crate-0.2.0 entry in:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn go_local_mode_with_module_path_suggests_ldflags() {
+        let mut info = rust_info();
+        info.template = Template::go;
+        info.fetcher = Fetcher::local;
+        info.go_module_path = "github.com/user/myapp".to_owned();
+        let expr = generate_expression(&info);
+        let out = info.format(&expr);
+        assert!(
+            out.contains("# ldflags = [ \"-X github.com/user/myapp/main.version="),
+            "expected commented ldflags suggestion in:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn go_remote_mode_no_ldflags() {
+        let mut info = rust_info();
+        info.template = Template::go;
+        info.go_module_path = String::new();
+        let expr = generate_expression(&info);
+        let out = info.format(&expr);
+        assert!(
+            !out.contains("ldflags"),
+            "should not contain ldflags when module path is unknown:\n{}",
             out
         );
     }
@@ -979,6 +1020,21 @@ pub fn generate_structured_flake_nix(template: &Template, pname: &str, directory
         {{
           {pname} = {attr_path};
           default = self.packages.${{system}}.{pname};
+        }}
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {{
+            inherit system;
+            overlays = [ self.overlays.default ];
+          }};
+        in
+        {{
+          default = pkgs.mkShell {{
+            inputsFrom = [ self.packages.${{system}}.default ];
+          }};
         }}
       );
     }};

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -125,7 +125,18 @@ fn build_inputs(info: &ExpressionInfo) -> String {
             // The lockFile path is ../Cargo.lock because the package
             // expression lives under nix/package.nix in the structured layout.
             let cargo_block = if info.use_cargo_lock_file {
-                "  cargoLock.lockFile = ../Cargo.lock;".to_owned()
+                let mut block = "  cargoLock.lockFile = ../Cargo.lock;".to_owned();
+                if !info.cargo_lock_git_deps.is_empty() {
+                    block.push_str("\n  cargoLock.outputHashes = {");
+                    for dep in &info.cargo_lock_git_deps {
+                        block.push_str(&format!(
+                            "\n    \"{}\" = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\";",
+                            dep
+                        ));
+                    }
+                    block.push_str("\n  };");
+                }
+                block
             } else {
                 "  @doc:cargoHash@cargoHash = \"@cargo_hash@\";".to_owned()
             };
@@ -434,6 +445,7 @@ mod tests {
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
+            cargo_lock_git_deps: Vec::new(),
             python_format: "setuptools".to_owned(),
         }
     }
@@ -478,6 +490,7 @@ mod tests {
             build_inputs: Vec::new(),
             native_build_inputs: Vec::new(),
             use_cargo_lock_file: false,
+            cargo_lock_git_deps: Vec::new(),
             python_format: "setuptools".to_owned(),
         }
     }
@@ -630,6 +643,34 @@ mod tests {
         assert!(
             !out.contains("cargoHash"),
             "should not contain cargoHash when using lockFile:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn rust_local_mode_with_git_deps_renders_output_hashes() {
+        let mut info = rust_info();
+        info.use_cargo_lock_file = true;
+        info.fetcher = Fetcher::local;
+        info.cargo_lock_git_deps = vec![
+            "some-crate-0.1.0".to_owned(),
+            "other-crate-0.2.0".to_owned(),
+        ];
+        let expr = generate_expression(&info);
+        let out = info.format(&expr);
+        assert!(
+            out.contains("cargoLock.outputHashes = {"),
+            "expected outputHashes block in:\n{}",
+            out
+        );
+        assert!(
+            out.contains("\"some-crate-0.1.0\" = \"sha256-"),
+            "expected some-crate-0.1.0 entry in:\n{}",
+            out
+        );
+        assert!(
+            out.contains("\"other-crate-0.2.0\" = \"sha256-"),
+            "expected other-crate-0.2.0 entry in:\n{}",
             out
         );
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,31 +1,29 @@
-use crate::types::{ExpressionInfo, Fetcher, Template, VENDOR_HASH_NULL};
+use crate::types::{ExpressionInfo, Fetcher, Template, StdenvVariant, VENDOR_HASH_NULL};
 
 fn derivation_helper(info: &ExpressionInfo) -> (String, String) {
-    let (input, derivation, documentation_key): (&str, &str, Option<&str>) = match info.template {
-        Template::auto => unreachable!("'auto' template should be resolved before expression generation"),
-        Template::stdenv => ("stdenv", "stdenv.mkDerivation", Some("stdenvMkDerivation")),
-        Template::stdenvNoCC => (
+    let (input, derivation, documentation_key): (&str, &str, Option<&str>) = match &info.template {
+        Template::Auto => unreachable!("'auto' template should be resolved before expression generation"),
+        Template::Stdenv(StdenvVariant::Default) => ("stdenv", "stdenv.mkDerivation", Some("stdenvMkDerivation")),
+        Template::Stdenv(StdenvVariant::NoCC) => (
             "stdenvNoCC",
             "stdenvNoCC.mkDerivation",
             Some("stdenvNoCCMkDerivation"),
         ),
-        // Python library packages use buildPythonPackage
-        Template::python_package => {
-            ("buildPythonPackage", "buildPythonPackage", None)
+        // Python library packages use buildPythonPackage; applications use buildPythonApplication
+        Template::Python(config) => {
+            match config.variant {
+                crate::types::PythonVariant::Package => ("buildPythonPackage", "buildPythonPackage", None),
+                crate::types::PythonVariant::Application => ("buildPythonApplication", "buildPythonApplication", None),
+            }
         }
-        // Python applications use buildPythonApplication
-        Template::python_application => {
-            ("buildPythonApplication", "buildPythonApplication", None)
-        }
-        Template::mkshell => ("pkgs ? import <nixpkgs> {}", "with pkgs;\n\nmkShell", None),
-        Template::go => ("buildGoModule", "buildGoModule", None),
-        Template::rust => ("rustPlatform", "rustPlatform.buildRustPackage", None),
-        Template::npm => ("buildNpmPackage", "buildNpmPackage", Some("buildNpmPackage")),
-        Template::pnpm => ("stdenv", "stdenv.mkDerivation", Some("stdenvMkDerivation")),
-        Template::dotnet => ("buildDotnetModule", "buildDotnetModule", Some("buildDotnetModule")),
-        Template::ruby => ("bundlerApp", "bundlerApp", Some("bundlerApp")),
-        Template::test => ("", "", None),  // Tests aren't a normal expression
-        Template::module => ("", "", None), // Modules aren't a normal expression
+        Template::Mkshell => ("pkgs ? import <nixpkgs> {}", "with pkgs;\n\nmkShell", None),
+        Template::Go(_) => ("buildGoModule", "buildGoModule", None),
+        Template::Rust(_) => ("rustPlatform", "rustPlatform.buildRustPackage", None),
+        Template::Node(_) => ("buildNpmPackage", "buildNpmPackage", Some("buildNpmPackage")),
+        Template::Dotnet => ("buildDotnetModule", "buildDotnetModule", Some("buildDotnetModule")),
+        Template::Ruby => ("bundlerApp", "bundlerApp", Some("bundlerApp")),
+        Template::Test => ("", "", None),  // Tests aren't a normal expression
+        Template::Module => ("", "", None), // Modules aren't a normal expression
     };
 
     match documentation_key {
@@ -95,7 +93,7 @@ fn fetch_block(fetcher: &Fetcher) -> (&'static str, &'static str) {
 
 fn addtional_pkg_attr_headers(template: &Template) -> &'static str {
     match template {
-        Template::python_package | Template::python_application => {
+        Template::Python(_) => {
             "\n  @doc:pythonFormat@format = \"@python_format@\";"
         }
         _ => "",
@@ -106,13 +104,13 @@ fn build_inputs(info: &ExpressionInfo) -> String {
     match info.template {
         // Python applications don't carry a Python-import smoke test the way
         // libraries do; their entry points are exercised at runtime.
-        Template::python_application =>
+        Template::Python(_) =>
             "  @doc:buildDependencies@propagatedBuildInputs = [@propagated_build_inputs@ ];".to_owned(),
         // Python packages (libraries) include pythonImportsCheck for smoke testing
-        Template::python_package => "  @doc:buildDependencies@propagatedBuildInputs = [@propagated_build_inputs@ ];
+        Template::Python(_) => "  @doc:buildDependencies@propagatedBuildInputs = [@propagated_build_inputs@ ];
 
   @doc:pythonImportsCheck@pythonImportsCheck = [ \"@pname-import-check@\" ];".to_owned(),
-        Template::rust => {
+        Template::Rust(_) => {
             // Conditionally render `nativeBuildInputs` only when inferred,
             // to keep the output tidy for projects without system deps.
             let native = if info.native_build_inputs.is_empty() {
@@ -148,7 +146,7 @@ fn build_inputs(info: &ExpressionInfo) -> String {
                 native = native,
             )
         }
-        Template::go => {
+        Template::Go(_) => {
             // Mirror the Rust path: only emit nativeBuildInputs / buildInputs
             // attributes when CGO inference produced something. Empty
             // attributes would just be noise users have to delete.
@@ -189,10 +187,10 @@ fn build_inputs(info: &ExpressionInfo) -> String {
                 ldflags = ldflags,
             )
         }
-        Template::npm => {
+        Template::Node(_) => {
             "  npmDepsHash = \"@npm_deps_hash@\";".to_owned()
         }
-        Template::pnpm => {
+        Template::Node(_) => {
             "  nativeBuildInputs = [
     nodejs
     pnpmConfigHook
@@ -206,10 +204,10 @@ fn build_inputs(info: &ExpressionInfo) -> String {
     hash = \"@pnpm_deps_hash@\";
   };".to_owned()
         }
-        Template::dotnet => {
+        Template::Dotnet => {
             "  projectFile = \"@project_file@\";\n  nugetDeps = ./deps.json;  # Run `nix-build -A package-name.passthru.fetch-deps` to generate".to_owned()
         }
-        Template::ruby => {
+        Template::Ruby => {
             // Conditionally render build inputs only when inferred
             let native = if info.native_build_inputs.is_empty() {
                 String::new()
@@ -254,8 +252,8 @@ fn meta() -> &'static str {
 
 pub fn generate_expression(info: &ExpressionInfo) -> String {
     match &info.template {
-        Template::auto => unreachable!("'auto' template should be resolved before expression generation"),
-        Template::module   => r#"@doc:nixosModules@{ pkgs, lib, config, ... }:
+        Template::Auto => unreachable!("'auto' template should be resolved before expression generation"),
+        Template::Module   => r#"@doc:nixosModules@{ pkgs, lib, config, ... }:
 
 with lib;
 
@@ -295,7 +293,7 @@ in {
 
   meta.maintainers = with lib.maintainers; [ @maintainer@ ];
 }"#.to_owned(),
-        Template::test => r#"import ./make-test-python.nix ({ pkgs, ... }:
+        Template::Test => r#"import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "@pname@";
   meta = with pkgs.lib.maintainers; {
@@ -317,7 +315,7 @@ in {
       machine.succeed("CMD")
     '';
 })"#.to_string(),
-        Template::mkshell => "with import <nixpkgs> { };
+        Template::Mkshell => "with import <nixpkgs> { };
 
 mkShell rec {
   # include any libraries or programs in buildInputs
@@ -330,7 +328,7 @@ mkShell rec {
 }
 "
         .to_string(),
-        Template::ruby => {
+        Template::Ruby => {
             let (_, dh_block) = derivation_helper(info);
             let meta_content = if info.include_meta { meta() } else { "" };
 
@@ -372,7 +370,7 @@ mkShell rec {
             inputs.extend(info.propagated_build_inputs.iter().map(|s| s.to_owned()));
 
             // pnpm template needs special inputs for fetchPnpmDeps and pnpm setup
-            if info.template == Template::pnpm {
+            if info.template == Template::pnpm() {
                 inputs.push("fetchPnpmDeps".to_string());
                 inputs.push("nodejs".to_string());
                 inputs.push("pnpm_10".to_string());
@@ -435,7 +433,7 @@ mod tests {
             license: "mit".to_owned(),
             maintainer: "me".to_owned(),
             fetcher: Fetcher::github,
-            template: Template::rust,
+            template: Template::rust(),
             path_to_write: std::path::PathBuf::new(),
             top_level_path: std::path::PathBuf::new(),
             include_documentation_links: false,
@@ -481,7 +479,7 @@ mod tests {
             license: "ofl".to_owned(),
             maintainer: "me".to_owned(),
             fetcher: Fetcher::github,
-            template: Template::stdenvNoCC,
+            template: Template::stdenv_nocc(),
             path_to_write: std::path::PathBuf::new(),
             top_level_path: std::path::PathBuf::new(),
             include_documentation_links: false,
@@ -550,7 +548,7 @@ mod tests {
         // via --build-inputs / --native-build-inputs. Both sections must
         // render and both attrs must surface in the function header.
         let mut info = rust_info();
-        info.template = Template::stdenv;
+        info.template = Template::stdenv();
         info.build_inputs = vec!["zlib".to_owned()];
         info.native_build_inputs = vec!["pkg-config".to_owned()];
         let expr = generate_expression(&info);
@@ -575,7 +573,7 @@ mod tests {
         // `buildInputs = [ ];` as a placeholder when nothing's supplied.
         // No nativeBuildInputs section unless inferred/asked for.
         let mut info = rust_info();
-        info.template = Template::stdenv;
+        info.template = Template::stdenv();
         info.build_inputs = Vec::new();
         info.native_build_inputs = Vec::new();
         let expr = generate_expression(&info);
@@ -690,7 +688,7 @@ mod tests {
     #[test]
     fn go_local_mode_with_module_path_suggests_ldflags() {
         let mut info = rust_info();
-        info.template = Template::go;
+        info.template = Template::go();
         info.fetcher = Fetcher::local;
         info.go_module_path = "github.com/user/myapp".to_owned();
         let expr = generate_expression(&info);
@@ -705,7 +703,7 @@ mod tests {
     #[test]
     fn go_remote_mode_no_ldflags() {
         let mut info = rust_info();
-        info.template = Template::go;
+        info.template = Template::go();
         info.go_module_path = String::new();
         let expr = generate_expression(&info);
         let out = info.format(&expr);
@@ -719,7 +717,7 @@ mod tests {
     #[test]
     fn go_vendor_null_renders_without_quotes() {
         let mut info = rust_info();
-        info.template = Template::go;
+        info.template = Template::go();
         info.vendor_hash = "null".to_owned();
         let expr = generate_expression(&info);
         let out = info.format(&expr);
@@ -738,7 +736,7 @@ mod tests {
     #[test]
     fn python_format_renders_detected_format() {
         let mut info = rust_info();
-        info.template = Template::python_package;
+        info.template = Template::python_package();
         info.python_format = "flit".to_owned();
         let expr = generate_expression(&info);
         let out = info.format(&expr);
@@ -783,7 +781,7 @@ pub fn generate_npins_sources_json() -> &'static str {
 /// from `generate_flake_nix` so that python packages resolve through
 /// `pkgs.python3Packages.callPackage`.
 pub fn generate_npins_wrapper_default_nix(template: &Template, package_file: &str) -> String {
-    let inner_attr_path = if *template == Template::python_package || *template == Template::python_application {
+    let inner_attr_path = if template.is_python() {
         ".python3Packages"
     } else {
         ""
@@ -807,7 +805,7 @@ pkgs{inner_attr_path}.callPackage ./{package_file} {{ }}
 }
 
 pub fn generate_flake_nix(template: &Template, output_file: &str, directory_name: &str) -> String {
-    let inner_attr_path = if *template == Template::python_package || *template == Template::python_application {
+    let inner_attr_path = if template.is_python() {
         ".python3Packages"
     } else {
         ""
@@ -857,7 +855,7 @@ pub fn generate_flake_nix(template: &Template, output_file: &str, directory_name
 /// packages are exposed. New packages are added by appending another
 /// `final.callPackage ./package.nix { };` line.
 pub fn generate_overlay_nix(template: &Template, pname: &str) -> String {
-    if *template == Template::module {
+    if *template == Template::Module {
         // Module-only projects don't have a package to expose. Emit an
         // empty overlay scaffold the user can fill in later.
         return r#"# Overlay generated by nix-template.
@@ -873,7 +871,7 @@ final: prev: {
     }
 
     let call_package = match template {
-        Template::python_package | Template::python_application => {
+        Template::Python(_) => {
             "final.python3Packages.callPackage"
         }
         _ => "final.callPackage",
@@ -915,7 +913,7 @@ in"#
 in"#
     };
 
-    if *template == Template::module {
+    if *template == Template::Module {
         // Module-only project: there is no package to surface. Expose
         // the overlay-extended nixpkgs so consumers can pull whatever
         // they need.
@@ -931,7 +929,7 @@ pkgs
         );
     }
 
-    let attr_path = if *template == Template::python_package || *template == Template::python_application {
+    let attr_path = if template.is_python() {
         format!("pkgs.python3Packages.{}", pname)
     } else {
         format!("pkgs.{}", pname)
@@ -955,7 +953,7 @@ pkgs
 /// rather than a sibling package file. Pairs with the structured layout
 /// produced by `--init-flake` (with nix/ layout) or `--init-npins`.
 pub fn generate_structured_flake_nix(template: &Template, pname: &str, directory_name: &str) -> String {
-    if *template == Template::module {
+    if *template == Template::Module {
         // Module-only flake: expose nixosModules instead of packages.
         return format!(
             r#"{{
@@ -980,7 +978,7 @@ pub fn generate_structured_flake_nix(template: &Template, pname: &str, directory
     }
 
     let attr_path = match template {
-        Template::python_package | Template::python_application => {
+        Template::Python(_) => {
             format!("pkgs.python3Packages.{}", pname)
         }
         _ => format!("pkgs.{}", pname),

--- a/src/file_path.rs
+++ b/src/file_path.rs
@@ -116,11 +116,17 @@ pub fn nix_file_paths(
     if path.as_os_str().to_string_lossy().ends_with("/") {
         // Validate that the path doesn't contain parent directory components (..)
         // This prevents path traversal attacks
-        if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
             eprintln!("Warning: Path contains '..' components, which may be unsafe");
         }
         path_buf.push("default.nix");
-        eprintln!("Directory was passed as [PATH], defaulting to {:?}", path_buf.display());
+        eprintln!(
+            "Directory was passed as [PATH], defaulting to {:?}",
+            path_buf.display()
+        );
     }
 
     (path_buf, PathBuf::from(""))
@@ -140,7 +146,6 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
-
 
     #[test]
     fn by_name_shard_basic() {

--- a/src/file_path.rs
+++ b/src/file_path.rs
@@ -65,7 +65,7 @@ impl NixDirLayout {
         // Use simple nix/package.nix layout for local project initialization
         let package_path = nix_dir.join("package.nix");
         let overlay_path = nix_dir.join("overlay.nix");
-        let module_path = if *template == Template::module {
+        let module_path = if *template == Template::Module {
             Some(nix_dir.join("modules").join(pname).join("default.nix"))
         } else {
             None

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -96,7 +96,11 @@ impl Autocomplete for FuzzyAutocomplete {
         }
         // Otherwise fall back to the top fuzzy match for what they
         // typed. This makes Tab behave like fzf's "accept best".
-        Ok(self.ranked(input).into_iter().next().map_or(Replacement::None, Replacement::Some))
+        Ok(self
+            .ranked(input)
+            .into_iter()
+            .next()
+            .map_or(Replacement::None, Replacement::Some))
     }
 }
 
@@ -286,8 +290,17 @@ mod autocomplete_tests {
 
     fn licenses() -> FuzzyAutocomplete {
         FuzzyAutocomplete::new(vec![
-            "mit", "asl20", "gpl3", "gpl2", "lgpl21", "bsd3", "bsd2",
-            "agpl3", "mpl20", "cc0", "unlicense",
+            "mit",
+            "asl20",
+            "gpl3",
+            "gpl2",
+            "lgpl21",
+            "bsd3",
+            "bsd2",
+            "agpl3",
+            "mpl20",
+            "cc0",
+            "unlicense",
         ])
     }
 
@@ -324,9 +337,7 @@ mod autocomplete_tests {
     #[test]
     fn tab_with_highlight_returns_highlighted() {
         let mut ac = licenses();
-        let r = ac
-            .get_completion("g", Some("gpl3".to_string()))
-            .unwrap();
+        let r = ac.get_completion("g", Some("gpl3".to_string())).unwrap();
         assert_eq!(r, Replacement::Some("gpl3".to_string()));
     }
 
@@ -350,9 +361,15 @@ mod autocomplete_tests {
 pub fn prompt_template_type(default: Option<Template>) -> Result<Template> {
     let options = vec![
         ("stdenv", "Standard environment derivation"),
-        ("stdenvNoCC", "Standard environment without a C compiler (fonts, data, scripts)"),
+        (
+            "stdenvNoCC",
+            "Standard environment without a C compiler (fonts, data, scripts)",
+        ),
         ("python-package", "Python library with buildPythonPackage"),
-        ("python-application", "Python application with buildPythonApplication"),
+        (
+            "python-application",
+            "Python application with buildPythonApplication",
+        ),
         ("rust", "Rust package with rustPlatform.buildRustPackage"),
         ("go", "Go package with buildGoModule"),
         ("npm", "Node.js package with buildNpmPackage"),
@@ -426,9 +443,7 @@ pub fn prompt_template_from_candidates(
     // Match back to the candidate by finding which one matches the displayed string
     let selected_idx = candidates
         .iter()
-        .position(|c| {
-            selection.starts_with(&format!("{}", c.template))
-        })
+        .position(|c| selection.starts_with(&format!("{}", c.template)))
         .unwrap_or(0);
 
     Ok(candidates[selected_idx].template.clone())
@@ -440,7 +455,10 @@ pub fn extract_metadata_from_url(url: &str) -> Result<UrlMetadata> {
 
     match repo {
         Repo::Github(gh_repo) => {
-            eprintln!("Fetching metadata from GitHub for {}/{}...", gh_repo.owner, gh_repo.repo);
+            eprintln!(
+                "Fetching metadata from GitHub for {}/{}...",
+                gh_repo.owner, gh_repo.repo
+            );
 
             let repo_info = fetch_github_repo_info(&gh_repo);
 
@@ -528,9 +546,10 @@ pub fn extract_metadata_from_url(url: &str) -> Result<UrlMetadata> {
 
 /// Prompt for URL (GitHub or PyPI) and return URL with extracted metadata
 pub fn prompt_url() -> Result<Option<(String, UrlMetadata)>> {
-    let should_provide = Confirm::new("Do you want to fetch metadata from a URL (GitHub/PyPI/Gitea)?")
-        .with_default(false)
-        .prompt()?;
+    let should_provide =
+        Confirm::new("Do you want to fetch metadata from a URL (GitHub/PyPI/Gitea)?")
+            .with_default(false)
+            .prompt()?;
 
     if !should_provide {
         return Ok(None);
@@ -724,9 +743,7 @@ pub fn prompt_version(url: Option<&str>, default: &str) -> Result<String> {
 
 /// Prompt for version manually
 fn prompt_version_manual(default: &str) -> Result<String> {
-    let version = Text::new("Version:")
-        .with_default(default)
-        .prompt()?;
+    let version = Text::new("Version:").with_default(default).prompt()?;
     Ok(version)
 }
 
@@ -740,7 +757,10 @@ pub fn prompt_pname(default: &str) -> Result<String> {
 
         // Validate length (max 255 characters for filesystem compatibility)
         if pname.len() > 255 {
-            eprintln!("Error: Package name too long (max 255 characters, got {})", pname.len());
+            eprintln!(
+                "Error: Package name too long (max 255 characters, got {})",
+                pname.len()
+            );
             continue;
         }
 
@@ -874,7 +894,10 @@ pub fn prompt_description(default: &str) -> Result<String> {
 
         // Validate length (reasonable limit for descriptions)
         if description.len() > 1000 {
-            eprintln!("Error: Description too long (max 1000 characters, got {})", description.len());
+            eprintln!(
+                "Error: Description too long (max 1000 characters, got {})",
+                description.len()
+            );
             continue;
         }
 
@@ -902,10 +925,10 @@ pub fn run_interactive_mode(
     run_interactive_mode_with_defaults(
         initial_template,
         user_config,
-        Vec::new(),      // detected_candidates
-        None,            // default_pname
-        None,            // inferred_deps
-        false,           // is_local_init
+        Vec::new(), // detected_candidates
+        None,       // default_pname
+        None,       // inferred_deps
+        false,      // is_local_init
     )
 }
 
@@ -933,11 +956,7 @@ pub fn run_interactive_mode_with_defaults(
     };
 
     // 2. URL (optional) - skip if we're in local init mode
-    let url_with_metadata = if is_local_init {
-        None
-    } else {
-        prompt_url()?
-    };
+    let url_with_metadata = if is_local_init { None } else { prompt_url()? };
 
     // Extract metadata for defaults
     let metadata = url_with_metadata
@@ -946,9 +965,7 @@ pub fn run_interactive_mode_with_defaults(
         .unwrap_or_default();
 
     // 3. Package name (use defaults: default_pname from init mode, or URL metadata)
-    let pname_default = default_pname
-        .as_deref()
-        .unwrap_or_else(|| &metadata.pname);
+    let pname_default = default_pname.as_deref().unwrap_or_else(|| &metadata.pname);
     let pname = prompt_pname(pname_default)?;
 
     // 4. Version (with auto-fetch if URL provided)
@@ -974,7 +991,7 @@ pub fn run_interactive_mode_with_defaults(
         Fetcher::github
     };
     let fetcher = if is_local_init {
-        Fetcher::local  // Force local fetcher in init mode
+        Fetcher::local // Force local fetcher in init mode
     } else {
         prompt_fetcher(default_fetcher, &template)?
     };
@@ -1032,10 +1049,8 @@ pub fn run_interactive_mode_with_defaults(
     // can decline at the prompt.
     // In init mode, dependencies are already inferred, so just use true.
     let infer_deps = if is_local_init && inferred_deps.is_some() {
-        true  // Already inferred in init mode
-    } else if (template.is_rust() || template.is_go())
-        && url_with_metadata.is_some()
-    {
+        true // Already inferred in init mode
+    } else if (template.is_rust() || template.is_go()) && url_with_metadata.is_some() {
         let prompt_text = if template.is_rust() {
             "Infer system dependencies from Cargo.toml/Cargo.lock?"
         } else {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -389,18 +389,18 @@ pub fn prompt_template_type(default: Option<Template>) -> Result<Template> {
     let template_name = selection.split_whitespace().next().unwrap();
 
     Ok(match template_name {
-        "stdenv" => Template::stdenv,
-        "stdenvNoCC" => Template::stdenvNoCC,
-        "python-package" => Template::python_package,
-        "python-application" => Template::python_application,
-        "rust" => Template::rust,
-        "go" => Template::go,
-        "npm" => Template::npm,
-        "pnpm" => Template::pnpm,
-        "mkshell" => Template::mkshell,
-        "module" => Template::module,
-        "test" => Template::test,
-        _ => Template::stdenv,
+        "stdenv" => Template::stdenv(),
+        "stdenvNoCC" => Template::stdenv_nocc(),
+        "python-package" => Template::python_package(),
+        "python-application" => Template::python_application(),
+        "rust" => Template::rust(),
+        "go" => Template::go(),
+        "npm" => Template::npm(),
+        "pnpm" => Template::pnpm(),
+        "mkshell" => Template::Mkshell,
+        "module" => Template::Module,
+        "test" => Template::Test,
+        _ => Template::stdenv(),
     })
 }
 
@@ -968,7 +968,7 @@ pub fn run_interactive_mode_with_defaults(
     } else if url_with_metadata.is_some() {
         // Use fetcher from URL metadata
         metadata.fetcher
-    } else if template == Template::python_package || template == Template::python_application {
+    } else if template.is_python() {
         Fetcher::pypi
     } else {
         Fetcher::github
@@ -997,8 +997,8 @@ pub fn run_interactive_mode_with_defaults(
         "nix/package.nix"
     } else {
         match template {
-            Template::mkshell => "shell.nix",
-            Template::test => "test.nix",
+            Template::Mkshell => "shell.nix",
+            Template::Test => "test.nix",
             _ => "default.nix",
         }
     };
@@ -1015,7 +1015,7 @@ pub fn run_interactive_mode_with_defaults(
 
     // Hash prefetching is enabled by default for Rust/Go templates when we have a real source.
     // Ask if the user wants to skip it (opt-out behavior).
-    let skip_vendor_hashes = if matches!(template, Template::rust | Template::go)
+    let skip_vendor_hashes = if matches!(template, Template::Rust(_) | Template::Go(_))
         && url_with_metadata.is_some()
     {
         Confirm::new("Skip automatic cargoHash/vendorHash computation? (runs nix-build by default)")
@@ -1033,10 +1033,10 @@ pub fn run_interactive_mode_with_defaults(
     // In init mode, dependencies are already inferred, so just use true.
     let infer_deps = if is_local_init && inferred_deps.is_some() {
         true  // Already inferred in init mode
-    } else if (template == Template::rust || template == Template::go)
+    } else if (template.is_rust() || template.is_go())
         && url_with_metadata.is_some()
     {
-        let prompt_text = if template == Template::rust {
+        let prompt_text = if template.is_rust() {
             "Infer system dependencies from Cargo.toml/Cargo.lock?"
         } else {
             "Infer system dependencies from CGO directives in *.go files?"

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,12 @@ fn main() {
     let user_config: Option<UserConfig> =
         if let Some(file) = xdg_dirs.find_config_file("config.toml") {
             match std::fs::read_to_string(&file) {
-                Ok(contents) => {
-                    toml::from_str(&contents).map_err(|e| {
+                Ok(contents) => toml::from_str(&contents)
+                    .map_err(|e| {
                         eprintln!("Warning: Could not parse config file {:?}: {}", file, e);
                         eprintln!("Continuing without user configuration...");
-                    }).ok()
-                }
+                    })
+                    .ok(),
                 Err(e) => {
                     eprintln!("Warning: Could not read config file {:?}: {}", file, e);
                     eprintln!("Continuing without user configuration...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod file_path;
 mod interactive;
 mod output;
 mod source;
+mod templates;
 mod types;
 mod url;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -35,9 +35,8 @@ pub fn write_new(path: &Path, content: &str, label: &str) {
     if let Some(parent) = path.parent() {
         if parent.to_str() != Some("") && !parent.exists() {
             println!("Creating directory: {}", parent.display());
-            std::fs::create_dir_all(parent).unwrap_or_else(|_| {
-                panic!("Was unable to create directory {}", parent.display())
-            });
+            std::fs::create_dir_all(parent)
+                .unwrap_or_else(|_| panic!("Was unable to create directory {}", parent.display()));
         }
     }
 
@@ -45,7 +44,7 @@ pub fn write_new(path: &Path, content: &str, label: &str) {
     // This prevents TOCTOU race conditions and symlink attacks
     match OpenOptions::new()
         .write(true)
-        .create_new(true)  // Atomic: fails if file exists
+        .create_new(true) // Atomic: fails if file exists
         .open(path)
     {
         Ok(mut file) => {
@@ -54,10 +53,7 @@ pub fn write_new(path: &Path, content: &str, label: &str) {
             });
         }
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            eprintln!(
-                "Refusing to overwrite existing file: {}",
-                path.display()
-            );
+            eprintln!("Refusing to overwrite existing file: {}", path.display());
             std::process::exit(1);
         }
         Err(e) => {
@@ -65,11 +61,7 @@ pub fn write_new(path: &Path, content: &str, label: &str) {
         }
     }
 
-    println!(
-        "Generated {} at {}",
-        label,
-        display_path(path).display()
-    );
+    println!("Generated {} at {}", label, display_path(path).display());
 }
 
 /// Write a file, creating parent directories as needed (allows overwriting).
@@ -79,9 +71,8 @@ pub fn write_file(path: &Path, content: &str) {
         // TODO: better way to determine that file will be written PWD
         if p.to_str() != Some("") && !p.exists() {
             println!("Creating directory: {}", p.display());
-            std::fs::create_dir_all(p).unwrap_or_else(|_| {
-                panic!("Was unable to create directory {}", p.display())
-            });
+            std::fs::create_dir_all(p)
+                .unwrap_or_else(|_| panic!("Was unable to create directory {}", p.display()));
         }
     }
     // write file

--- a/src/source.rs
+++ b/src/source.rs
@@ -20,7 +20,9 @@ const LOG_TARGET: &str = "nix-template::source";
 /// the source hash is not yet known.
 pub fn materialise_source(info: &ExpressionInfo) -> Option<PathBuf> {
     if info.src_sha.is_empty()
-        || info.src_sha.starts_with("0000000000000000000000000000000000000000000000000000")
+        || info
+            .src_sha
+            .starts_with("0000000000000000000000000000000000000000000000000000")
     {
         debug!(target: LOG_TARGET, "src_sha not yet known; skipping source materialisation");
         return None;

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -22,4 +22,3 @@
 pub mod types;
 
 // Re-export all template types for convenient access
-pub use types::*;

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,0 +1,25 @@
+//! Template type system and utilities for nix-template.
+//!
+//! This module provides a hierarchical type system for templates, where each
+//! language or framework has its own configuration struct with variant-specific
+//! settings.
+//!
+//! # Examples
+//!
+//! ```
+//! use nix_template::templates::types::{Template, PythonConfig, PythonVariant, PythonFormat};
+//!
+//! // Parse from CLI string
+//! let template: Template = "python_package".parse().unwrap();
+//! assert!(template.is_python());
+//!
+//! // Access Python-specific config
+//! if let Some(config) = template.python_config() {
+//!     println!("Format: {}", config.format.as_str());
+//! }
+//! ```
+
+pub mod types;
+
+// Re-export all template types for convenient access
+pub use types::*;

--- a/src/templates/types.rs
+++ b/src/templates/types.rs
@@ -77,6 +77,7 @@ pub enum PythonFormat {
 
 impl PythonFormat {
     /// Convert to nixpkgs `format` attribute value.
+    #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
         match self {
             PythonFormat::Setuptools => "setuptools",
@@ -305,6 +306,7 @@ impl Template {
     }
 
     /// Get Python config if this is a Python template.
+    #[allow(dead_code)]
     pub fn python_config(&self) -> Option<&PythonConfig> {
         match self {
             Template::Python(config) => Some(config),
@@ -326,6 +328,7 @@ impl Template {
     }
 
     /// Get Rust config if this is a Rust template.
+    #[allow(dead_code)]
     pub fn rust_config(&self) -> Option<&RustConfig> {
         match self {
             Template::Rust(config) => Some(config),
@@ -334,6 +337,7 @@ impl Template {
     }
 
     /// Get mutable Rust config.
+    #[allow(dead_code)]
     pub fn rust_config_mut(&mut self) -> Option<&mut RustConfig> {
         match self {
             Template::Rust(config) => Some(config),
@@ -347,6 +351,7 @@ impl Template {
     }
 
     /// Get Go config if this is a Go template.
+    #[allow(dead_code)]
     pub fn go_config(&self) -> Option<&GoConfig> {
         match self {
             Template::Go(config) => Some(config),
@@ -355,6 +360,7 @@ impl Template {
     }
 
     /// Get mutable Go config.
+    #[allow(dead_code)]
     pub fn go_config_mut(&mut self) -> Option<&mut GoConfig> {
         match self {
             Template::Go(config) => Some(config),
@@ -368,6 +374,7 @@ impl Template {
     }
 
     /// Get Node config if this is a Node template.
+    #[allow(dead_code)]
     pub fn node_config(&self) -> Option<&NodeConfig> {
         match self {
             Template::Node(config) => Some(config),
@@ -376,6 +383,7 @@ impl Template {
     }
 
     /// Get mutable Node config.
+    #[allow(dead_code)]
     pub fn node_config_mut(&mut self) -> Option<&mut NodeConfig> {
         match self {
             Template::Node(config) => Some(config),
@@ -414,7 +422,10 @@ mod tests {
             Template::Stdenv(StdenvVariant::NoCC)
         );
         assert!("python_package".parse::<Template>().unwrap().is_python());
-        assert!("python_application".parse::<Template>().unwrap().is_python());
+        assert!("python_application"
+            .parse::<Template>()
+            .unwrap()
+            .is_python());
         assert!("rust".parse::<Template>().unwrap().is_rust());
         assert!("go".parse::<Template>().unwrap().is_go());
         assert!("npm".parse::<Template>().unwrap().is_node());
@@ -502,10 +513,7 @@ mod tests {
         assert_eq!(PythonFormat::Setuptools.as_str(), "setuptools");
         assert_eq!(PythonFormat::Flit.as_str(), "flit");
         assert_eq!(PythonFormat::from_str("poetry"), PythonFormat::Poetry);
-        assert_eq!(
-            PythonFormat::from_str("HATCHLING"),
-            PythonFormat::Hatchling
-        );
+        assert_eq!(PythonFormat::from_str("HATCHLING"), PythonFormat::Hatchling);
     }
 
     #[test]

--- a/src/templates/types.rs
+++ b/src/templates/types.rs
@@ -1,0 +1,523 @@
+//! Hierarchical template type system for nix-template.
+//!
+//! This module defines a tree-like structure for templates, where each
+//! language or framework has its own configuration struct containing
+//! variant-specific settings (e.g., Python has package/application variants
+//! and multiple build formats; Rust has different lock file strategies).
+
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// Top-level template type with hierarchical variants.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Template {
+    /// Auto-detect template from source tree (requires --from-url)
+    Auto,
+    /// stdenv.mkDerivation or stdenvNoCC.mkDerivation
+    Stdenv(StdenvVariant),
+    /// Python package or application with build format
+    Python(PythonConfig),
+    /// Rust package with lock file strategy
+    Rust(RustConfig),
+    /// Go module with optional module path
+    Go(GoConfig),
+    /// Node.js package (npm or pnpm)
+    Node(NodeConfig),
+    /// .NET package (buildDotnetModule)
+    Dotnet,
+    /// Ruby application (bundlerApp)
+    Ruby,
+    /// Development shell (mkShell)
+    Mkshell,
+    /// NixOS module
+    Module,
+    /// Test template
+    Test,
+}
+
+/// Stdenv variants: default (with CC) or NoCC (compiler-less).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StdenvVariant {
+    /// stdenv.mkDerivation (includes compiler toolchain)
+    Default,
+    /// stdenvNoCC.mkDerivation (pure data, fonts, scripts)
+    NoCC,
+}
+
+/// Python template configuration: variant (package vs application) × format.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PythonConfig {
+    pub variant: PythonVariant,
+    pub format: PythonFormat,
+}
+
+/// Python package variant: library or application.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PythonVariant {
+    /// buildPythonPackage (library, reusable package)
+    Package,
+    /// buildPythonApplication (CLI tool, standalone app)
+    Application,
+}
+
+/// Python build system format (detected from pyproject.toml).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PythonFormat {
+    /// format = "setuptools" (legacy setup.py)
+    Setuptools,
+    /// format = "pyproject" (PEP 517/518, generic)
+    Pyproject,
+    /// format = "flit" (flit_core backend)
+    Flit,
+    /// format = "poetry" (poetry-core backend)
+    Poetry,
+    /// format = "hatchling" (hatchling backend)
+    Hatchling,
+}
+
+impl PythonFormat {
+    /// Convert to nixpkgs `format` attribute value.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PythonFormat::Setuptools => "setuptools",
+            PythonFormat::Pyproject => "pyproject",
+            PythonFormat::Flit => "flit",
+            PythonFormat::Poetry => "poetry",
+            PythonFormat::Hatchling => "hatchling",
+        }
+    }
+
+    /// Parse from string (case-insensitive).
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "setuptools" => PythonFormat::Setuptools,
+            "pyproject" => PythonFormat::Pyproject,
+            "flit" => PythonFormat::Flit,
+            "poetry" => PythonFormat::Poetry,
+            "hatchling" => PythonFormat::Hatchling,
+            _ => PythonFormat::Setuptools, // fallback
+        }
+    }
+}
+
+/// Rust template configuration: variant and lock file strategy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RustConfig {
+    pub variant: RustVariant,
+    pub lock_strategy: RustLockStrategy,
+}
+
+/// Rust package variant (currently only one, but extensible).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RustVariant {
+    /// rustPlatform.buildRustPackage (library or binary)
+    Package,
+}
+
+/// Rust dependency locking strategy: cargoHash or cargoLock.lockFile.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RustLockStrategy {
+    /// cargoHash = "sha256-..." (for nixpkgs, remote sources)
+    CargoHash,
+    /// cargoLock.lockFile = ./Cargo.lock (for local development)
+    LockFile {
+        /// Git dependency keys needing outputHashes entries
+        git_deps: Vec<String>,
+    },
+}
+
+/// Go template configuration: variant and module path.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GoConfig {
+    pub variant: GoVariant,
+    /// Module path from go.mod (e.g., "github.com/user/repo")
+    /// Used to suggest ldflags for version embedding.
+    pub module_path: Option<String>,
+}
+
+/// Go package variant (currently only one, but extensible).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GoVariant {
+    /// buildGoModule (any Go module)
+    Module,
+}
+
+/// Node.js template configuration: npm or pnpm.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeConfig {
+    pub variant: NodeVariant,
+}
+
+/// Node.js package manager variant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum NodeVariant {
+    /// buildNpmPackage (package-lock.json)
+    Npm,
+    /// stdenv.mkDerivation + pnpmConfigHook (pnpm-lock.yaml)
+    Pnpm,
+}
+
+/// CLI-friendly template names for argument parsing.
+/// These maintain backward compatibility with the original flat structure.
+pub const CLI_TEMPLATES: &[&str] = &[
+    "auto",
+    "stdenv",
+    "stdenvNoCC",
+    "python_package",
+    "python_application",
+    "rust",
+    "go",
+    "npm",
+    "pnpm",
+    "dotnet",
+    "ruby",
+    "mkshell",
+    "module",
+    "test",
+];
+
+impl Template {
+    /// Return all CLI template variant strings (for clap's possible_values).
+    pub fn variants() -> Vec<&'static str> {
+        CLI_TEMPLATES.to_vec()
+    }
+
+    /// Create a default Rust template (uses CargoHash strategy).
+    pub fn rust() -> Self {
+        Template::Rust(RustConfig {
+            variant: RustVariant::Package,
+            lock_strategy: RustLockStrategy::CargoHash,
+        })
+    }
+
+    /// Create a default Go template.
+    pub fn go() -> Self {
+        Template::Go(GoConfig {
+            variant: GoVariant::Module,
+            module_path: None,
+        })
+    }
+
+    /// Create a default Python package template (with setuptools format).
+    pub fn python_package() -> Self {
+        Template::Python(PythonConfig {
+            variant: PythonVariant::Package,
+            format: PythonFormat::Setuptools,
+        })
+    }
+
+    /// Create a default Python application template (with setuptools format).
+    pub fn python_application() -> Self {
+        Template::Python(PythonConfig {
+            variant: PythonVariant::Application,
+            format: PythonFormat::Setuptools,
+        })
+    }
+
+    /// Create a default npm template.
+    pub fn npm() -> Self {
+        Template::Node(NodeConfig {
+            variant: NodeVariant::Npm,
+        })
+    }
+
+    /// Create a default pnpm template.
+    pub fn pnpm() -> Self {
+        Template::Node(NodeConfig {
+            variant: NodeVariant::Pnpm,
+        })
+    }
+
+    /// Create a default stdenv template.
+    pub fn stdenv() -> Self {
+        Template::Stdenv(StdenvVariant::Default)
+    }
+
+    /// Create a stdenvNoCC template.
+    pub fn stdenv_nocc() -> Self {
+        Template::Stdenv(StdenvVariant::NoCC)
+    }
+
+    /// Parse from CLI string argument (case-insensitive).
+    pub fn parse_cli(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Template::Auto),
+            "stdenv" => Ok(Template::Stdenv(StdenvVariant::Default)),
+            "stdenvnocc" => Ok(Template::Stdenv(StdenvVariant::NoCC)),
+            "python_package" => Ok(Template::Python(PythonConfig {
+                variant: PythonVariant::Package,
+                format: PythonFormat::Setuptools, // default, detected later
+            })),
+            "python_application" => Ok(Template::Python(PythonConfig {
+                variant: PythonVariant::Application,
+                format: PythonFormat::Setuptools,
+            })),
+            "rust" => Ok(Template::Rust(RustConfig {
+                variant: RustVariant::Package,
+                lock_strategy: RustLockStrategy::CargoHash,
+            })),
+            "go" => Ok(Template::Go(GoConfig {
+                variant: GoVariant::Module,
+                module_path: None,
+            })),
+            "npm" => Ok(Template::Node(NodeConfig {
+                variant: NodeVariant::Npm,
+            })),
+            "pnpm" => Ok(Template::Node(NodeConfig {
+                variant: NodeVariant::Pnpm,
+            })),
+            "dotnet" => Ok(Template::Dotnet),
+            "ruby" => Ok(Template::Ruby),
+            "mkshell" => Ok(Template::Mkshell),
+            "module" => Ok(Template::Module),
+            "test" => Ok(Template::Test),
+            _ => Err(format!("Unknown template: {}", s)),
+        }
+    }
+
+    /// Convert to CLI string for display and serialization.
+    pub fn to_cli_str(&self) -> &'static str {
+        match self {
+            Template::Auto => "auto",
+            Template::Stdenv(StdenvVariant::Default) => "stdenv",
+            Template::Stdenv(StdenvVariant::NoCC) => "stdenvNoCC",
+            Template::Python(config) => match config.variant {
+                PythonVariant::Package => "python_package",
+                PythonVariant::Application => "python_application",
+            },
+            Template::Rust(_) => "rust",
+            Template::Go(_) => "go",
+            Template::Node(config) => match config.variant {
+                NodeVariant::Npm => "npm",
+                NodeVariant::Pnpm => "pnpm",
+            },
+            Template::Dotnet => "dotnet",
+            Template::Ruby => "ruby",
+            Template::Mkshell => "mkshell",
+            Template::Module => "module",
+            Template::Test => "test",
+        }
+    }
+
+    /// Check if this is a Python template (any variant).
+    pub fn is_python(&self) -> bool {
+        matches!(self, Template::Python(_))
+    }
+
+    /// Get Python config if this is a Python template.
+    pub fn python_config(&self) -> Option<&PythonConfig> {
+        match self {
+            Template::Python(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Get mutable Python config.
+    pub fn python_config_mut(&mut self) -> Option<&mut PythonConfig> {
+        match self {
+            Template::Python(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Check if this is a Rust template.
+    pub fn is_rust(&self) -> bool {
+        matches!(self, Template::Rust(_))
+    }
+
+    /// Get Rust config if this is a Rust template.
+    pub fn rust_config(&self) -> Option<&RustConfig> {
+        match self {
+            Template::Rust(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Get mutable Rust config.
+    pub fn rust_config_mut(&mut self) -> Option<&mut RustConfig> {
+        match self {
+            Template::Rust(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Check if this is a Go template.
+    pub fn is_go(&self) -> bool {
+        matches!(self, Template::Go(_))
+    }
+
+    /// Get Go config if this is a Go template.
+    pub fn go_config(&self) -> Option<&GoConfig> {
+        match self {
+            Template::Go(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Get mutable Go config.
+    pub fn go_config_mut(&mut self) -> Option<&mut GoConfig> {
+        match self {
+            Template::Go(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Check if this is a Node template (any variant).
+    pub fn is_node(&self) -> bool {
+        matches!(self, Template::Node(_))
+    }
+
+    /// Get Node config if this is a Node template.
+    pub fn node_config(&self) -> Option<&NodeConfig> {
+        match self {
+            Template::Node(config) => Some(config),
+            _ => None,
+        }
+    }
+
+    /// Get mutable Node config.
+    pub fn node_config_mut(&mut self) -> Option<&mut NodeConfig> {
+        match self {
+            Template::Node(config) => Some(config),
+            _ => None,
+        }
+    }
+}
+
+impl FromStr for Template {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Template::parse_cli(s)
+    }
+}
+
+impl std::fmt::Display for Template {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_cli_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cli_templates() {
+        assert_eq!("auto".parse::<Template>().unwrap(), Template::Auto);
+        assert_eq!(
+            "stdenv".parse::<Template>().unwrap(),
+            Template::Stdenv(StdenvVariant::Default)
+        );
+        assert_eq!(
+            "stdenvNoCC".parse::<Template>().unwrap(),
+            Template::Stdenv(StdenvVariant::NoCC)
+        );
+        assert!("python_package".parse::<Template>().unwrap().is_python());
+        assert!("python_application".parse::<Template>().unwrap().is_python());
+        assert!("rust".parse::<Template>().unwrap().is_rust());
+        assert!("go".parse::<Template>().unwrap().is_go());
+        assert!("npm".parse::<Template>().unwrap().is_node());
+        assert!("pnpm".parse::<Template>().unwrap().is_node());
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        assert_eq!(
+            "STDENV".parse::<Template>().unwrap(),
+            Template::Stdenv(StdenvVariant::Default)
+        );
+        assert_eq!(
+            "Python_Package".parse::<Template>().unwrap().to_cli_str(),
+            "python_package"
+        );
+    }
+
+    #[test]
+    fn parse_unknown_template() {
+        assert!("unknown".parse::<Template>().is_err());
+    }
+
+    #[test]
+    fn to_cli_str_round_trip() {
+        for variant in CLI_TEMPLATES {
+            let parsed: Template = variant.parse().unwrap();
+            assert_eq!(parsed.to_cli_str(), *variant);
+        }
+    }
+
+    #[test]
+    fn python_config_access() {
+        let mut tmpl: Template = "python_package".parse().unwrap();
+        assert!(tmpl.is_python());
+        assert_eq!(
+            tmpl.python_config().unwrap().variant,
+            PythonVariant::Package
+        );
+
+        // Mutate format
+        tmpl.python_config_mut().unwrap().format = PythonFormat::Flit;
+        assert_eq!(tmpl.python_config().unwrap().format, PythonFormat::Flit);
+    }
+
+    #[test]
+    fn rust_config_access() {
+        let mut tmpl: Template = "rust".parse().unwrap();
+        assert!(tmpl.is_rust());
+        assert_eq!(
+            tmpl.rust_config().unwrap().lock_strategy,
+            RustLockStrategy::CargoHash
+        );
+
+        // Mutate lock strategy
+        tmpl.rust_config_mut().unwrap().lock_strategy = RustLockStrategy::LockFile {
+            git_deps: vec!["foo-0.1.0".to_string()],
+        };
+        assert!(matches!(
+            tmpl.rust_config().unwrap().lock_strategy,
+            RustLockStrategy::LockFile { .. }
+        ));
+    }
+
+    #[test]
+    fn node_variant_distinction() {
+        let npm: Template = "npm".parse().unwrap();
+        let pnpm: Template = "pnpm".parse().unwrap();
+
+        assert!(npm.is_node());
+        assert!(pnpm.is_node());
+
+        assert!(matches!(
+            npm.node_config().unwrap().variant,
+            NodeVariant::Npm
+        ));
+        assert!(matches!(
+            pnpm.node_config().unwrap().variant,
+            NodeVariant::Pnpm
+        ));
+    }
+
+    #[test]
+    fn python_format_str_conversion() {
+        assert_eq!(PythonFormat::Setuptools.as_str(), "setuptools");
+        assert_eq!(PythonFormat::Flit.as_str(), "flit");
+        assert_eq!(PythonFormat::from_str("poetry"), PythonFormat::Poetry);
+        assert_eq!(
+            PythonFormat::from_str("HATCHLING"),
+            PythonFormat::Hatchling
+        );
+    }
+
+    #[test]
+    fn go_config_module_path() {
+        let mut tmpl: Template = "go".parse().unwrap();
+        assert!(tmpl.is_go());
+        assert_eq!(tmpl.go_config().unwrap().module_path, None);
+
+        tmpl.go_config_mut().unwrap().module_path = Some("github.com/user/repo".to_string());
+        assert_eq!(
+            tmpl.go_config().unwrap().module_path.as_deref(),
+            Some("github.com/user/repo")
+        );
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -207,6 +207,9 @@ pub struct ExpressionInfo {
     /// `cargoLock.outputHashes` entries. Only populated when
     /// `use_cargo_lock_file` is true.
     pub cargo_lock_git_deps: Vec<String>,
+    /// Go module path from `go.mod` (e.g. `github.com/user/repo`).
+    /// Used to suggest `ldflags` for version embedding. Empty when unknown.
+    pub go_module_path: String,
     /// Python build system format, detected from pyproject.toml or defaulted.
     /// One of: "setuptools", "pyproject", "flit", "poetry", "hatchling".
     pub python_format: String,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -219,7 +219,11 @@ impl ExpressionInfo {
                 // Deduplicate and sort inputs
                 let unique: std::collections::BTreeSet<_> = inputs.iter().collect();
                 let sorted: Vec<&String> = unique.into_iter().collect();
-                let body = sorted.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n    ");
+                let body = sorted
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n    ");
                 format!("\n    {}\n ", body)
             }
         }
@@ -242,9 +246,15 @@ impl ExpressionInfo {
             .replace("@homepage@", &self.homepage)
             .replace("@license@", &self.license)
             .replace("@maintainer@", &self.maintainer)
-            .replace("@propagated_build_inputs@", &format_inputs(&self.propagated_build_inputs))
+            .replace(
+                "@propagated_build_inputs@",
+                &format_inputs(&self.propagated_build_inputs),
+            )
             .replace("@build_inputs@", &format_inputs(&self.build_inputs))
-            .replace("@native_build_inputs@", &format_inputs(&self.native_build_inputs))
+            .replace(
+                "@native_build_inputs@",
+                &format_inputs(&self.native_build_inputs),
+            )
             .replace("@python_format@", &self.python_format);
 
         if self.include_documentation_links {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -203,6 +203,10 @@ pub struct ExpressionInfo {
     /// When true, the Rust template renders `cargoLock.lockFile = ./Cargo.lock;`
     /// instead of `cargoHash = "...";`. Automatically set in local mode.
     pub use_cargo_lock_file: bool,
+    /// Git dependency keys (`"name-version"`) from `Cargo.lock` that need
+    /// `cargoLock.outputHashes` entries. Only populated when
+    /// `use_cargo_lock_file` is true.
+    pub cargo_lock_git_deps: Vec<String>,
     /// Python build system format, detected from pyproject.toml or defaulted.
     /// One of: "setuptools", "pyproject", "flit", "poetry", "hatchling".
     pub python_format: String,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -200,10 +200,21 @@ pub struct ExpressionInfo {
     /// Inferred build-time tools (rendered into `nativeBuildInputs` for
     /// the `rust` template). Common entries: `pkg-config`, `cmake`.
     pub native_build_inputs: Vec<String>,
+    /// When true, the Rust template renders `cargoLock.lockFile = ./Cargo.lock;`
+    /// instead of `cargoHash = "...";`. Automatically set in local mode.
+    pub use_cargo_lock_file: bool,
+    /// Python build system format, detected from pyproject.toml or defaulted.
+    /// One of: "setuptools", "pyproject", "flit", "poetry", "hatchling".
+    pub python_format: String,
 }
 
 /// Default SRI placeholder used by `lib.fakeHash` in nixpkgs.
 pub const FAKE_SRI_HASH: &str = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+/// Sentinel value for `vendor_hash` that renders as `vendorHash = null;`
+/// (without quotes) in the Go template. Used when a local project has a
+/// committed `vendor/` directory.
+pub const VENDOR_HASH_NULL: &str = "null";
 
 impl ExpressionInfo {
     pub fn format(&self, s: &str) -> String {
@@ -245,7 +256,8 @@ impl ExpressionInfo {
             .replace("@maintainer@", &self.maintainer)
             .replace("@propagated_build_inputs@", &format_inputs(&self.propagated_build_inputs))
             .replace("@build_inputs@", &format_inputs(&self.build_inputs))
-            .replace("@native_build_inputs@", &format_inputs(&self.native_build_inputs));
+            .replace("@native_build_inputs@", &format_inputs(&self.native_build_inputs))
+            .replace("@python_format@", &self.python_format);
 
         if self.include_documentation_links {
             Self::insert_documentation_links(result)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -14,6 +14,9 @@ pub use gh_repo_response::*;
 pub use gitlab_response::*;
 pub use pypi::*;
 
+// Re-export template types from the templates module for backward compatibility
+pub use crate::templates::types::*;
+
 lazy_static! {
     static ref DOCUMENTATION_LINKS: HashMap<&'static str, &'static str> = {
         let mut m = HashMap::new();
@@ -82,30 +85,8 @@ lazy_static! {
     static ref DOC_LINKS_REGEX: Regex = Regex::new(r"@doc:(\w+)@").unwrap();
 }
 
-// `stdenvNoCC` is the C-compiler-less variant of `stdenv`. It follows the
-// same workflow as `stdenv` (same default install path, same fetcher
-// surface) but renders `stdenvNoCC.mkDerivation` for packages that don't
-// compile code — fonts, pure data, shell-script wrappers, etc.
-arg_enum! {
-    #[allow(non_camel_case_types)]
-    #[derive(Debug, PartialEq, Clone)]
-    pub enum Template {
-        auto,
-        stdenv,
-        stdenvNoCC,
-        python_package,
-        python_application,
-        module,
-        mkshell,
-        go,
-        rust,
-        npm,
-        pnpm,
-        dotnet,
-        ruby,
-        test,
-    }
-}
+// Template types have been moved to the template module.
+// The new hierarchical Template enum is now re-exported above.
 
 arg_enum! {
     #[allow(non_camel_case_types)]

--- a/src/url.rs
+++ b/src/url.rs
@@ -1092,6 +1092,7 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         native_build_inputs: Vec::new(),
         use_cargo_lock_file: false,
         cargo_lock_git_deps: Vec::new(),
+        go_module_path: String::new(),
         python_format: "setuptools".to_owned(),
     };
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -1080,6 +1080,8 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         // we want a minimal expression that just exercises src + cargo.
         build_inputs: Vec::new(),
         native_build_inputs: Vec::new(),
+        use_cargo_lock_file: false,
+        python_format: "setuptools".to_owned(),
     };
 
     let probe_expr = crate::expression::generate_expression(&probe_info);

--- a/src/url.rs
+++ b/src/url.rs
@@ -1037,7 +1037,7 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
 
     // Only Rust, Go, npm, and pnpm packages need dependency hash prefetching.
     match info.template {
-        Template::rust | Template::go | Template::npm | Template::pnpm => (),
+        Template::Rust(_) | Template::Go(_) | Template::Node(_) | Template::Node(_) => (),
         _ => return None,
     }
 
@@ -1047,7 +1047,7 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
     if info.use_cargo_lock_file {
         return None;
     }
-    if info.template == Template::go && info.vendor_hash == types::VENDOR_HASH_NULL {
+    if info.template.is_go() && info.vendor_hash == types::VENDOR_HASH_NULL {
         return None;
     }
 
@@ -1122,11 +1122,13 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         }
     }
 
-    let kind = match info.template {
-        Template::rust => "cargoHash",
-        Template::go => "vendorHash",
-        Template::npm => "npmDepsHash",
-        Template::pnpm => "pnpmDeps hash",
+    let kind = match &info.template {
+        Template::Rust(_) => "cargoHash",
+        Template::Go(_) => "vendorHash",
+        Template::Node(config) => match config.variant {
+            crate::types::NodeVariant::Npm => "npmDepsHash",
+            crate::types::NodeVariant::Pnpm => "pnpmDepsHash",
+        },
         _ => unreachable!(),
     };
     eprintln!("Prefetching {} for {} (this may take a while)...", kind, &info.pname);

--- a/src/url.rs
+++ b/src/url.rs
@@ -105,10 +105,7 @@ fn validate_url_component(component: &str, field_name: &str) -> Result<()> {
 
     // Check for null bytes specifically (even though covered above)
     if component.contains('\0') {
-        return Err(anyhow!(
-            "Invalid {}: contains null bytes",
-            field_name
-        ));
+        return Err(anyhow!("Invalid {}: contains null bytes", field_name));
     }
 
     // Check for excessive length (DoS prevention)
@@ -122,10 +119,7 @@ fn validate_url_component(component: &str, field_name: &str) -> Result<()> {
 
     // Check that it's not empty
     if component.trim().is_empty() {
-        return Err(anyhow!(
-            "Invalid {}: cannot be empty",
-            field_name
-        ));
+        return Err(anyhow!("Invalid {}: cannot be empty", field_name));
     }
 
     Ok(())
@@ -172,14 +166,21 @@ fn validate_version_components(version: &str, tag_prefix: &str) -> Result<()> {
 }
 
 fn to_sri(hash: &str) -> String {
-   let sha256_cmd = Command::new("nix")
-     .args(&["hash", "to-sri", "--type", "sha256", "--experimental-features", "nix-command"])
-     .arg(hash)
-     .output();
-   std::str::from_utf8(&sha256_cmd.expect("failed to run 'nix hash'").stdout)
-     .unwrap()
-     .trim()
-     .to_owned()
+    let sha256_cmd = Command::new("nix")
+        .args(&[
+            "hash",
+            "to-sri",
+            "--type",
+            "sha256",
+            "--experimental-features",
+            "nix-command",
+        ])
+        .arg(hash)
+        .output();
+    std::str::from_utf8(&sha256_cmd.expect("failed to run 'nix hash'").stdout)
+        .unwrap()
+        .trim()
+        .to_owned()
 }
 
 /// Heuristic detection of prerelease tags for platforms that don't have
@@ -493,11 +494,10 @@ pub fn fill_github_info(repo: &types::GithubRepo, info: &mut types::ExpressionIn
                 &repo.owner, &repo.repo, &info.tag_prefix, &info.version
             ))
             .output();
-        let output = String::from_utf8_lossy(
-            &sha256_cmd.expect("failed to run 'nix-prefetch-url'").stdout,
-        )
-        .trim()
-        .to_owned();
+        let output =
+            String::from_utf8_lossy(&sha256_cmd.expect("failed to run 'nix-prefetch-url'").stdout)
+                .trim()
+                .to_owned();
         info.src_sha = to_sri(&output);
     } else {
         eprintln!(
@@ -528,7 +528,11 @@ pub fn fill_github_info(repo: &types::GithubRepo, info: &mut types::ExpressionIn
 /// Uses GitLab's API v4 to fetch release and project information.
 /// Supports nested groups (e.g., gitlab.com/org/subgroup/repo).
 /// The project_path is URL-encoded for API calls.
-pub fn fill_gitlab_info(repo: &types::GitlabRepo, info: &mut types::ExpressionInfo, include_prereleases: bool) {
+pub fn fill_gitlab_info(
+    repo: &types::GitlabRepo,
+    info: &mut types::ExpressionInfo,
+    include_prereleases: bool,
+) {
     // Validate repo components to prevent injection attacks
     if let Err(e) = validate_gitlab_repo(repo) {
         error!(target: LOG_TARGET, "Invalid GitLab repository: {}", e);
@@ -663,11 +667,8 @@ pub fn fill_gitlab_info(repo: &types::GitlabRepo, info: &mut types::ExpressionIn
                 match sha256_cmd {
                     Ok(output) => {
                         if output.status.success() {
-                            info.src_sha = to_sri(
-                                String::from_utf8_lossy(&output.stdout)
-                                    .to_string()
-                                    .trim(),
-                            );
+                            info.src_sha =
+                                to_sri(String::from_utf8_lossy(&output.stdout).to_string().trim());
                         } else {
                             eprintln!(
                                 "Warning: nix-prefetch-url failed: {}",
@@ -699,7 +700,8 @@ pub fn fill_gitlab_info(repo: &types::GitlabRepo, info: &mut types::ExpressionIn
 
             match get_json(tags_request) {
                 Ok(tags_body) => {
-                    let tags_result: Result<types::GitlabTagsResponse, _> = serde_json::from_str(&tags_body);
+                    let tags_result: Result<types::GitlabTagsResponse, _> =
+                        serde_json::from_str(&tags_body);
                     if let Ok(mut tags) = tags_result {
                         if !tags.is_empty() {
                             // Sort by tag name using version comparison
@@ -757,7 +759,10 @@ pub fn fill_gitlab_info(repo: &types::GitlabRepo, info: &mut types::ExpressionIn
                                             }
                                         }
                                         Err(e) => {
-                                            eprintln!("Warning: Could not run nix-prefetch-url: {}", e);
+                                            eprintln!(
+                                                "Warning: Could not run nix-prefetch-url: {}",
+                                                e
+                                            );
                                         }
                                     }
                                 }
@@ -840,7 +845,10 @@ pub fn fill_gitea_info(repo: &types::GiteaRepo, info: &mut types::ExpressionInfo
 
     let request_client = Client::new();
 
-    eprintln!("Determining latest release for {}/{}", &repo.owner, &repo.repo);
+    eprintln!(
+        "Determining latest release for {}/{}",
+        &repo.owner, &repo.repo
+    );
     let releases_url = format!(
         "https://{}/api/v1/repos/{}/{}/releases",
         repo.domain, repo.owner, repo.repo
@@ -868,14 +876,13 @@ pub fn fill_gitea_info(repo: &types::GiteaRepo, info: &mut types::ExpressionInfo
                     });
                     releases = releases.into_iter().filter(|a| !a.prerelease).collect();
                     if let Some(latest) = releases.first() {
-                        let parsed_version =
-                            VERSION_REGEX.captures(&latest.tag_name).unwrap();
+                        let parsed_version = VERSION_REGEX.captures(&latest.tag_name).unwrap();
                         info.version = parsed_version.get(2).unwrap().as_str().to_owned();
-                        info.tag_prefix =
-                            parsed_version.get(1).unwrap().as_str().to_owned();
+                        info.tag_prefix = parsed_version.get(1).unwrap().as_str().to_owned();
 
                         // Validate version components before using in commands
-                        if let Err(e) = validate_version_components(&info.version, &info.tag_prefix) {
+                        if let Err(e) = validate_version_components(&info.version, &info.tag_prefix)
+                        {
                             error!(target: LOG_TARGET, "Invalid version from Gitea API: {}", e);
                             eprintln!("Error: {}", e);
                             exit(1);
@@ -885,11 +892,7 @@ pub fn fill_gitea_info(repo: &types::GiteaRepo, info: &mut types::ExpressionInfo
                         // Gitea archive URL: <domain>/<owner>/<repo>/archive/<tag>.tar.gz
                         let archive_url = format!(
                             "https://{}/{}/{}/archive/{}{}.tar.gz",
-                            &repo.domain,
-                            &repo.owner,
-                            &repo.repo,
-                            &info.tag_prefix,
-                            &info.version,
+                            &repo.domain, &repo.owner, &repo.repo, &info.tag_prefix, &info.version,
                         );
                         let sha256_cmd = Command::new("nix-prefetch-url")
                             .args(&["--unpack", "--type", "sha256"])
@@ -934,21 +937,15 @@ pub fn fill_gitea_info(repo: &types::GiteaRepo, info: &mut types::ExpressionInfo
         // GhRepoResponse deserializer where compatible.
         if let Ok(parsed) = serde_json::from_str::<types::GhRepoResponse>(&body) {
             if info.description == "CHANGE" {
-                info.description = parsed
-                    .description
-                    .unwrap_or_else(|| "CHANGE".to_owned());
+                info.description = parsed.description.unwrap_or_else(|| "CHANGE".to_owned());
             }
         }
     }
 
-    info.homepage = format!(
-        "https://{}/{}/{}",
-        repo.domain, repo.owner, repo.repo
-    );
+    info.homepage = format!("https://{}/{}/{}", repo.domain, repo.owner, repo.repo);
 }
 
 pub fn fill_pypi_info(pypi_repo: &types::PypiRepo, info: &mut types::ExpressionInfo) {
-
     eprintln!("Determining latest release for {}", &pypi_repo.project);
     let pypi_response = fetch_pypi_project_info(pypi_repo);
     if info.pname == "CHANGE" {
@@ -985,16 +982,28 @@ pub fn fill_pypi_info(pypi_repo: &types::PypiRepo, info: &mut types::ExpressionI
             .to_string();
 
         // Grab dependencies, filter out extras, normalize names
-        debug!("Python dependencies before normalization: {:?}", &pypi_response.info.requires_dist);
-        let mut dependencies: Vec<String> = pypi_response.info.requires_dist
+        debug!(
+            "Python dependencies before normalization: {:?}",
+            &pypi_response.info.requires_dist
+        );
+        let mut dependencies: Vec<String> = pypi_response
+            .info
+            .requires_dist
             .unwrap_or_else(|| Vec::new())
             .into_iter()
             .filter(|s| !s.contains("extra =="))
-            .map(|s| s.split(" ").next().unwrap()
-                // Remove version information
-                .chars().take_while( |&ch| ch != '!' && ch != '<' && ch != '>' && ch != '=').collect::<String>()
-                // Normalize name to adhere to Nixpkgs conventions
-                .replace(".", "-").replace("_", "-"))
+            .map(|s| {
+                s.split(" ")
+                    .next()
+                    .unwrap()
+                    // Remove version information
+                    .chars()
+                    .take_while(|&ch| ch != '!' && ch != '<' && ch != '>' && ch != '=')
+                    .collect::<String>()
+                    // Normalize name to adhere to Nixpkgs conventions
+                    .replace(".", "-")
+                    .replace("_", "-")
+            })
             .collect();
         dependencies.sort();
         debug!("dependencies after normalization: {:?}", &dependencies);
@@ -1037,7 +1046,7 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
 
     // Only Rust, Go, npm, and pnpm packages need dependency hash prefetching.
     match info.template {
-        Template::Rust(_) | Template::Go(_) | Template::Node(_) | Template::Node(_) => (),
+        Template::Rust(_) | Template::Go(_) | Template::Node(_) => (),
         _ => return None,
     }
 
@@ -1053,7 +1062,9 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
 
     // We can't prefetch without a real source hash to feed the builder.
     if info.src_sha.is_empty()
-        || info.src_sha.starts_with("0000000000000000000000000000000000000000000000000000")
+        || info
+            .src_sha
+            .starts_with("0000000000000000000000000000000000000000000000000000")
     {
         eprintln!("Skipping hash prefetch: src_sha is not yet known");
         return None;
@@ -1112,12 +1123,18 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         let mut f = match std::fs::File::create(&probe_path) {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("Skipping hash prefetch: failed to write probe expression: {}", e);
+                eprintln!(
+                    "Skipping hash prefetch: failed to write probe expression: {}",
+                    e
+                );
                 return None;
             }
         };
         if let Err(e) = f.write_all(probe_text.as_bytes()) {
-            eprintln!("Skipping hash prefetch: failed to write probe expression: {}", e);
+            eprintln!(
+                "Skipping hash prefetch: failed to write probe expression: {}",
+                e
+            );
             return None;
         }
     }
@@ -1131,7 +1148,10 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         },
         _ => unreachable!(),
     };
-    eprintln!("Prefetching {} for {} (this may take a while)...", kind, &info.pname);
+    eprintln!(
+        "Prefetching {} for {} (this may take a while)...",
+        kind, &info.pname
+    );
 
     let output = Command::new("nix-build")
         .args(&["--no-out-link", "-E"])
@@ -1208,7 +1228,11 @@ pub fn infer_dotnet_project_file(info: &types::ExpressionInfo) -> Option<String>
     // 2. .fsproj files (F#)
     // 3. .sln files (Solution)
 
-    fn find_project_files_impl(dir: &Path, extension: &str, depth: usize) -> Vec<std::path::PathBuf> {
+    fn find_project_files_impl(
+        dir: &Path,
+        extension: &str,
+        depth: usize,
+    ) -> Vec<std::path::PathBuf> {
         use std::fs;
 
         // Base case: if depth is 0, stop recursing
@@ -1291,9 +1315,9 @@ pub fn read_meta_from_url(url: &str, info: &mut types::ExpressionInfo, include_p
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pretty_assertions::assert_eq;
-    use crate::types::Repo::{Github, Gitea};
+    use crate::types::Repo::{Gitea, Github};
     use crate::types::{GiteaRepo, GithubRepo};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_url_parse() {
@@ -1303,10 +1327,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(repo, Github(GithubRepo {
-            owner: "jonringer".to_string(),
-            repo: "nix-template".to_string()
-        }));
+        assert_eq!(
+            repo,
+            Github(GithubRepo {
+                owner: "jonringer".to_string(),
+                repo: "nix-template".to_string()
+            })
+        );
     }
 
     #[test]
@@ -1317,26 +1344,29 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(repo, Gitea(GiteaRepo {
-            domain: "codeberg.org".to_string(),
-            owner: "forgejo".to_string(),
-            repo: "forgejo".to_string(),
-        }));
+        assert_eq!(
+            repo,
+            Gitea(GiteaRepo {
+                domain: "codeberg.org".to_string(),
+                owner: "forgejo".to_string(),
+                repo: "forgejo".to_string(),
+            })
+        );
     }
 
     #[test]
     fn test_gitea_com_url_parse() {
-        let repo = validate_and_parse_url(
-            "gitea.com/user/project",
-            "gitea.com/user/project",
-        )
-        .unwrap();
+        let repo =
+            validate_and_parse_url("gitea.com/user/project", "gitea.com/user/project").unwrap();
 
-        assert_eq!(repo, Gitea(GiteaRepo {
-            domain: "gitea.com".to_string(),
-            owner: "user".to_string(),
-            repo: "project".to_string(),
-        }));
+        assert_eq!(
+            repo,
+            Gitea(GiteaRepo {
+                domain: "gitea.com".to_string(),
+                owner: "user".to_string(),
+                repo: "project".to_string(),
+            })
+        );
     }
 
     #[test]
@@ -1393,7 +1423,7 @@ mod tests {
             let captured_hash = captures.get(1).unwrap().as_str();
             // Should capture at most "sha256-" + 100 chars
             assert!(
-                captured_hash.len() <= 107,  // "sha256-" (7 chars) + 100 chars
+                captured_hash.len() <= 107, // "sha256-" (7 chars) + 100 chars
                 "Should not capture more than bounded amount"
             );
         }
@@ -1431,7 +1461,7 @@ mod tests {
         // Test that bounded quantifier prevents ReDoS from nested quantifiers
         // The old pattern ^([0-9.]*)+$ would cause catastrophic backtracking
         let mut malicious_input = "1".repeat(100);
-        malicious_input.push('X');  // Doesn't end with valid chars
+        malicious_input.push('X'); // Doesn't end with valid chars
 
         // Should complete quickly and not match
         let result = STABLE_RELEASE_REGEX.is_match(&malicious_input);

--- a/src/url.rs
+++ b/src/url.rs
@@ -1041,6 +1041,16 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         _ => return None,
     }
 
+    // Skip when the hash is already determined:
+    // - Rust with cargoLock.lockFile doesn't need cargoHash.
+    // - Go with a committed vendor/ directory uses vendorHash = null.
+    if info.use_cargo_lock_file {
+        return None;
+    }
+    if info.template == Template::go && info.vendor_hash == types::VENDOR_HASH_NULL {
+        return None;
+    }
+
     // We can't prefetch without a real source hash to feed the builder.
     if info.src_sha.is_empty()
         || info.src_sha.starts_with("0000000000000000000000000000000000000000000000000000")
@@ -1081,6 +1091,7 @@ pub fn prefetch_dependency_hash(info: &types::ExpressionInfo) -> Option<String> 
         build_inputs: Vec::new(),
         native_build_inputs: Vec::new(),
         use_cargo_lock_file: false,
+        cargo_lock_git_deps: Vec::new(),
         python_format: "setuptools".to_owned(),
     };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,11 +10,15 @@ fn test_python_template_basic() {
     let output = cmd
         .args(&[
             "python_package",
-            "-p", "requests",
-            "-v", "2.31.0",
-            "-l", "asl20",
-            "--maintainer", "",
-            "-s",  // --stdout flag
+            "-p",
+            "requests",
+            "-v",
+            "2.31.0",
+            "-l",
+            "asl20",
+            "--maintainer",
+            "",
+            "-s", // --stdout flag
         ])
         .output()
         .unwrap();
@@ -47,11 +51,15 @@ fn test_python_template_with_flake_init() {
     let output = cmd
         .args(&[
             "python_package",
-            "-p", "requests",
-            "-v", "2.31.0",
-            "-l", "asl20",
-            "--maintainer", "",
-            "-s",  // --stdout flag
+            "-p",
+            "requests",
+            "-v",
+            "2.31.0",
+            "-l",
+            "asl20",
+            "--maintainer",
+            "",
+            "-s", // --stdout flag
             "--init-flake",
         ])
         .output()
@@ -65,13 +73,13 @@ fn test_python_template_with_flake_init() {
     assert!(stdout.contains("# ===== nix/overlay.nix ====="));
 
     // stdout ordering from main.rs is: package → flake → overlay.
-    let after_flake_marker: Vec<&str> =
-        stdout.split("# ===== flake.nix =====").collect();
+    let after_flake_marker: Vec<&str> = stdout.split("# ===== flake.nix =====").collect();
     assert_eq!(after_flake_marker.len(), 2, "Expected a flake.nix marker");
     let package_nix = after_flake_marker[0].trim();
 
-    let after_overlay_marker: Vec<&str> =
-        after_flake_marker[1].split("# ===== nix/overlay.nix =====").collect();
+    let after_overlay_marker: Vec<&str> = after_flake_marker[1]
+        .split("# ===== nix/overlay.nix =====")
+        .collect();
     assert_eq!(after_overlay_marker.len(), 2, "Expected an overlay marker");
     let flake_nix = after_overlay_marker[0].trim();
     let overlay_nix = after_overlay_marker[1].trim();
@@ -119,11 +127,16 @@ fn test_python_template_pypi_fetcher_explicit() {
     let output = cmd
         .args(&[
             "python_package",
-            "-f", "pypi",  // Explicitly specify PyPI fetcher
-            "-p", "requests",
-            "-v", "2.31.0",
-            "-l", "asl20",
-            "--maintainer", "",
+            "-f",
+            "pypi", // Explicitly specify PyPI fetcher
+            "-p",
+            "requests",
+            "-v",
+            "2.31.0",
+            "-l",
+            "asl20",
+            "--maintainer",
+            "",
             "-s",
         ])
         .output()
@@ -134,7 +147,10 @@ fn test_python_template_pypi_fetcher_explicit() {
 
     // Verify fetchPypi is used
     assert!(stdout.contains("fetchPypi"));
-    assert!(!stdout.contains("fetchFromGitHub"), "Should not use GitHub fetcher");
+    assert!(
+        !stdout.contains("fetchFromGitHub"),
+        "Should not use GitHub fetcher"
+    );
 
     insta::assert_snapshot!("python_pypi_explicit_package", stdout);
 }
@@ -147,11 +163,16 @@ fn test_python_template_github_fetcher_override() {
     let output = cmd
         .args(&[
             "python_package",
-            "-f", "github",  // Override with GitHub fetcher
-            "-p", "requests",
-            "-v", "2.31.0",
-            "-l", "asl20",
-            "--maintainer", "",
+            "-f",
+            "github", // Override with GitHub fetcher
+            "-p",
+            "requests",
+            "-v",
+            "2.31.0",
+            "-l",
+            "asl20",
+            "--maintainer",
+            "",
             "-s",
         ])
         .output()
@@ -187,10 +208,14 @@ fn test_python_template_file_writing_with_flake() {
         .current_dir(temp_path)
         .args(&[
             "python_package",
-            "-p", "requests",
-            "-v", "2.31.0",
-            "-l", "asl20",
-            "--maintainer", "",
+            "-p",
+            "requests",
+            "-v",
+            "2.31.0",
+            "-l",
+            "asl20",
+            "--maintainer",
+            "",
             "--init-flake",
             // No -s flag, so it will write files
         ])
@@ -209,7 +234,10 @@ fn test_python_template_file_writing_with_flake() {
         package_nix_path.exists(),
         "nix/package.nix should be created"
     );
-    assert!(overlay_nix_path.exists(), "nix/overlay.nix should be created");
+    assert!(
+        overlay_nix_path.exists(),
+        "nix/overlay.nix should be created"
+    );
     assert!(flake_nix_path.exists(), "flake.nix should be created");
     assert!(
         !top_default_nix_path.exists(),
@@ -263,10 +291,14 @@ fn test_init_npins_stdout() {
     let output = cmd
         .args(&[
             "stdenv",
-            "-p", "hello",
-            "-v", "1.0",
-            "-l", "mit",
-            "--maintainer", "",
+            "-p",
+            "hello",
+            "-v",
+            "1.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "",
             "-s",
             "--init-npins",
         ])
@@ -316,10 +348,14 @@ fn test_init_npins_writes_three_files_and_renames() {
         .current_dir(temp_path)
         .args(&[
             "stdenv",
-            "-p", "hello",
-            "-v", "1.0",
-            "-l", "mit",
-            "--maintainer", "",
+            "-p",
+            "hello",
+            "-v",
+            "1.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "",
             "--init-npins",
         ])
         .output()
@@ -328,8 +364,15 @@ fn test_init_npins_writes_three_files_and_renames() {
     assert!(output.status.success(), "Command failed: {:?}", output);
 
     // Package lives under nix/pkgs/<pname>/package.nix
-    let package_nix = temp_path.join("nix").join("pkgs").join("hello").join("package.nix");
-    assert!(package_nix.exists(), "nix/pkgs/hello/package.nix should be created");
+    let package_nix = temp_path
+        .join("nix")
+        .join("pkgs")
+        .join("hello")
+        .join("package.nix");
+    assert!(
+        package_nix.exists(),
+        "nix/pkgs/hello/package.nix should be created"
+    );
 
     // Top-level default.nix wraps the overlay, replacing the legacy npins
     // wrapper that used to live alongside the package file.
@@ -353,8 +396,14 @@ fn test_init_npins_writes_three_files_and_renames() {
     // npins/ scaffold exists at project root.
     let npins_default = temp_path.join("npins").join("default.nix");
     let npins_sources = temp_path.join("npins").join("sources.json");
-    assert!(npins_default.exists(), "npins/default.nix should be created");
-    assert!(npins_sources.exists(), "npins/sources.json should be created");
+    assert!(
+        npins_default.exists(),
+        "npins/default.nix should be created"
+    );
+    assert!(
+        npins_sources.exists(),
+        "npins/sources.json should be created"
+    );
 
     let sources_content = std::fs::read_to_string(&npins_sources).unwrap();
     assert!(sources_content.contains("\"pins\": {}"));
@@ -388,10 +437,14 @@ fn test_init_npins_python_wrapper() {
         .current_dir(temp_path)
         .args(&[
             "python_package",
-            "-p", "requests",
-            "-v", "2.31.0",
-            "-l", "asl20",
-            "--maintainer", "",
+            "-p",
+            "requests",
+            "-v",
+            "2.31.0",
+            "-l",
+            "asl20",
+            "--maintainer",
+            "",
             "--init-npins",
         ])
         .output()
@@ -409,7 +462,9 @@ fn test_init_npins_python_wrapper() {
     // The overlay should use python3Packages.callPackage.
     let overlay = std::fs::read_to_string(temp_path.join("nix").join("overlay.nix")).unwrap();
     assert!(
-        overlay.contains("requests = final.python3Packages.callPackage ./pkgs/requests/package.nix { }"),
+        overlay.contains(
+            "requests = final.python3Packages.callPackage ./pkgs/requests/package.nix { }"
+        ),
         "Python overlay should use python3Packages.callPackage; got:\n{}",
         overlay
     );
@@ -433,10 +488,14 @@ fn test_init_npins_with_init_flake() {
         .current_dir(temp_path)
         .args(&[
             "stdenv",
-            "-p", "hello",
-            "-v", "1.0",
-            "-l", "mit",
-            "--maintainer", "",
+            "-p",
+            "hello",
+            "-v",
+            "1.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "",
             "--init-npins",
             "--init-flake",
         ])
@@ -448,14 +507,31 @@ fn test_init_npins_with_init_flake() {
     // Structured layout: package + overlay under nix/, flake/default at root,
     // npins/ at root.
     assert!(
-        temp_path.join("nix").join("pkgs").join("hello").join("package.nix").exists(),
+        temp_path
+            .join("nix")
+            .join("pkgs")
+            .join("hello")
+            .join("package.nix")
+            .exists(),
         "nix/pkgs/hello/package.nix should exist"
     );
-    assert!(temp_path.join("nix").join("overlay.nix").exists(), "nix/overlay.nix");
-    assert!(temp_path.join("default.nix").exists(), "top-level default.nix");
+    assert!(
+        temp_path.join("nix").join("overlay.nix").exists(),
+        "nix/overlay.nix"
+    );
+    assert!(
+        temp_path.join("default.nix").exists(),
+        "top-level default.nix"
+    );
     assert!(temp_path.join("flake.nix").exists(), "flake.nix");
-    assert!(temp_path.join("npins").join("default.nix").exists(), "npins/default.nix");
-    assert!(temp_path.join("npins").join("sources.json").exists(), "npins/sources.json");
+    assert!(
+        temp_path.join("npins").join("default.nix").exists(),
+        "npins/default.nix"
+    );
+    assert!(
+        temp_path.join("npins").join("sources.json").exists(),
+        "npins/sources.json"
+    );
 
     // Top-level default.nix imports the overlay applied to npins-pinned nixpkgs.
     let wrapper = std::fs::read_to_string(temp_path.join("default.nix")).unwrap();
@@ -491,10 +567,14 @@ fn test_init_npins_refuses_overwrite() {
         .current_dir(temp_path)
         .args(&[
             "stdenv",
-            "-p", "hello",
-            "-v", "1.0",
-            "-l", "mit",
-            "--maintainer", "",
+            "-p",
+            "hello",
+            "-v",
+            "1.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "",
             "--init-npins",
         ])
         .output()
@@ -509,8 +589,7 @@ fn test_init_npins_refuses_overwrite() {
     );
 
     // Pre-existing file should be untouched
-    let preserved =
-        std::fs::read_to_string(temp_path.join("npins").join("default.nix")).unwrap();
+    let preserved = std::fs::read_to_string(temp_path.join("npins").join("default.nix")).unwrap();
     assert_eq!(preserved, "# pre-existing npins reader\n");
 }
 
@@ -520,10 +599,14 @@ fn test_npm_template_basic() {
     let output = cmd
         .args(&[
             "npm",
-            "-p", "example",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "",
+            "-p",
+            "example",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "",
             "-s",
         ])
         .output()
@@ -547,10 +630,14 @@ fn test_pnpm_template_basic() {
     let output = cmd
         .args(&[
             "pnpm",
-            "-p", "example",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "",
+            "-p",
+            "example",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "",
             "-s",
         ])
         .output()
@@ -576,7 +663,8 @@ fn test_dotnet_template_basic() {
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().join("default.nix");
 
-    let output = Command::cargo_bin("nix-template").unwrap()
+    let output = Command::cargo_bin("nix-template")
+        .unwrap()
         .args(&[
             "dotnet",
             "--pname",
@@ -620,7 +708,8 @@ fn test_ruby_template_basic() {
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().join("default.nix");
 
-    let output = Command::cargo_bin("nix-template").unwrap()
+    let output = Command::cargo_bin("nix-template")
+        .unwrap()
         .args(&[
             "ruby",
             "--pname",
@@ -644,7 +733,7 @@ fn test_ruby_template_basic() {
     // Verify it contains bundlerApp (NOT finalAttrs pattern)
     assert!(stdout.contains("bundlerApp"));
     assert!(stdout.contains("bundlerApp {"));
-    assert!(!stdout.contains("finalAttrs"));  // Ruby doesn't use finalAttrs
+    assert!(!stdout.contains("finalAttrs")); // Ruby doesn't use finalAttrs
     assert!(stdout.contains("gemdir = ./.;"));
     assert!(stdout.contains("exes = [ \"example\" ];"));
 
@@ -689,7 +778,8 @@ BUNDLED WITH
 
     let output_path = temp_dir.path().join("default.nix");
 
-    let output = Command::cargo_bin("nix-template").unwrap()
+    let output = Command::cargo_bin("nix-template")
+        .unwrap()
         .current_dir(temp_dir.path())
         .args(&[
             "ruby",
@@ -731,10 +821,14 @@ fn test_file_write_shows_success_message() {
     let output = cmd
         .args(&[
             "stdenv",
-            "-p", "test-package",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "Test User",
+            "-p",
+            "test-package",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "Test User",
             output_path.to_str().unwrap(),
         ])
         .output()
@@ -785,10 +879,14 @@ fn test_write_new_atomic_overwrite_prevention() {
     let output = cmd
         .args(&[
             "stdenv",
-            "-p", "test-overwrite",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "Test",
+            "-p",
+            "test-overwrite",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "Test",
             output_path.to_str().unwrap(),
         ])
         .output()
@@ -812,8 +910,7 @@ fn test_write_new_atomic_overwrite_prevention() {
     // Original file should be preserved unchanged
     let preserved_content = fs::read_to_string(&output_path).unwrap();
     assert_eq!(
-        preserved_content,
-        "# original content\n",
+        preserved_content, "# original content\n",
         "Original file should not have been modified"
     );
 }
@@ -821,7 +918,7 @@ fn test_write_new_atomic_overwrite_prevention() {
 /// Test that write_new won't follow symlinks to overwrite target files.
 /// This prevents symlink attack scenarios.
 #[test]
-#[cfg(unix)]  // Symlinks work differently on Windows
+#[cfg(unix)] // Symlinks work differently on Windows
 fn test_write_new_prevents_symlink_attacks() {
     use std::os::unix::fs::symlink;
 
@@ -840,10 +937,14 @@ fn test_write_new_prevents_symlink_attacks() {
     let output = cmd
         .args(&[
             "stdenv",
-            "-p", "symlink-test",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "Test",
+            "-p",
+            "symlink-test",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "Test",
             symlink_path.to_str().unwrap(),
         ])
         .output()
@@ -858,8 +959,7 @@ fn test_write_new_prevents_symlink_attacks() {
     // Important: the target file should remain unchanged
     let preserved_content = fs::read_to_string(&target_file).unwrap();
     assert_eq!(
-        preserved_content,
-        "important data\n",
+        preserved_content, "important data\n",
         "Target file should not have been modified through symlink"
     );
 }
@@ -884,11 +984,15 @@ fn test_corrupted_config_file_doesnt_crash() {
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .args(&[
             "stdenv",
-            "-p", "test-config",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "Test",
-            "-s",  // Use stdout to avoid file creation
+            "-p",
+            "test-config",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "Test",
+            "-s", // Use stdout to avoid file creation
         ])
         .output()
         .unwrap();
@@ -935,11 +1039,15 @@ fn test_malformed_toml_config_doesnt_crash() {
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .args(&[
             "stdenv",
-            "-p", "test-toml",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "Test",
-            "-s",  // Use stdout to avoid file creation
+            "-p",
+            "test-toml",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "Test",
+            "-s", // Use stdout to avoid file creation
         ])
         .output()
         .unwrap();
@@ -970,7 +1078,7 @@ fn test_malformed_toml_config_doesnt_crash() {
 /// Test that the program works when config directory cannot be created
 /// (simulated by using a read-only location)
 #[test]
-#[cfg(unix)]  // Unix-specific test using permissions
+#[cfg(unix)] // Unix-specific test using permissions
 fn test_no_config_directory_doesnt_crash() {
     // This test verifies that if XDG setup fails entirely,
     // the program uses fallback and continues
@@ -982,7 +1090,7 @@ fn test_no_config_directory_doesnt_crash() {
     // Make directory read-only
     use std::os::unix::fs::PermissionsExt;
     let mut perms = fs::metadata(&readonly_dir).unwrap().permissions();
-    perms.set_mode(0o444);  // Read-only
+    perms.set_mode(0o444); // Read-only
     fs::set_permissions(&readonly_dir, perms).unwrap();
 
     // Try to use the read-only directory as config home
@@ -991,10 +1099,14 @@ fn test_no_config_directory_doesnt_crash() {
         .env("XDG_CONFIG_HOME", &readonly_dir)
         .args(&[
             "stdenv",
-            "-p", "test-readonly",
-            "-v", "1.0.0",
-            "-l", "mit",
-            "--maintainer", "Test",
+            "-p",
+            "test-readonly",
+            "-v",
+            "1.0.0",
+            "-l",
+            "mit",
+            "--maintainer",
+            "Test",
             "-s",
         ])
         .output()


### PR DESCRIPTION
Templates and their variants (python_application vs python_package) are a bit messy. I would like to normalize the structure as there's a lot of potential for other ecosystems as well (E.g. rust x (cargoHash | cargoLock) )